### PR TITLE
Handlers not triggered properly

### DIFF
--- a/roles/hadoop/tasks/main.yml
+++ b/roles/hadoop/tasks/main.yml
@@ -100,6 +100,11 @@
     - hdfs-site.xml.j2
     - yarn-site.xml.j2
     - mapred-site.xml.j2
+  register: hadoop_config
+  tags: hadoop
+  
+- name: restart hadoop to apply configuration changes
+  set_fact: hadoop_config_changed={{ hadoop_config.changed or (hadoop_config_changed is defined and hadoop_config_changed) }}
   notify:
     - restart hdfs namenode
     - wait for hdfs namenode port
@@ -111,6 +116,7 @@
     - wait for yarn node manager port
     - restart yarn history server
     - wait for yarn history server port
+  changed_when: hadoop_config_changed
   tags: hadoop
 
 - include: hdfs-namenode.yml

--- a/roles/hbase/handlers/main.yml
+++ b/roles/hbase/handlers/main.yml
@@ -3,7 +3,7 @@
   supervisorctl:
     name=hbase-master
     state=restarted
-  when: hbase_master_enabled and (hbase_config_changed is defined and hbase_config_changed)
+  when: hbase_master_enabled
 
 - name: wait for hbase master port
   wait_for:
@@ -16,7 +16,7 @@
   supervisorctl:
     name=hbase-regionserver
     state=restarted
-  when: hbase_regionserver_enabled and (hbase_config_changed is defined and hbase_config_changed)
+  when: hbase_regionserver_enabled
 
 - name: wait for hbase region server port
   wait_for:
@@ -28,7 +28,7 @@
   supervisorctl:
     name=hbase-rest
     state=restarted
-  when: hbase_rest_enabled and (hbase_config_changed is defined and hbase_config_changed)
+  when: hbase_rest_enabled
 
 - name: wait for hbase rest port
   wait_for:

--- a/roles/spark/tasks/main.yml
+++ b/roles/spark/tasks/main.yml
@@ -79,7 +79,6 @@
     - wait for spark master port
     - restart spark worker
     - wait for spark worker port
-    - restart spark history server
   changed_when: spark_config_changed
   tags: spark
 

--- a/roles/spark/tasks/main.yml
+++ b/roles/spark/tasks/main.yml
@@ -69,7 +69,18 @@
   with_items:
     - "spark-env.sh"
     - "spark-defaults.conf"
-  notify: reread supervisord
+  register: spark_config
+  tags: spark
+  
+- name: restart spark to apply configuration changes
+  set_fact: spark_config_changed={{ spark_config.changed or (spark_config_changed is defined and spark_config_changed) }}
+  notify:
+    - restart spark master
+    - wait for spark master port
+    - restart spark worker
+    - wait for spark worker port
+    - restart spark history server
+  changed_when: spark_config_changed
   tags: spark
 
 - name: delete spark conf templates

--- a/roles/spark/tasks/spark-master.yml
+++ b/roles/spark/tasks/spark-master.yml
@@ -25,5 +25,4 @@
     mode=0644
   notify:
     - reread supervisord
-    - restart spark master
   tags: spark

--- a/roles/spark/tasks/spark-worker.yml
+++ b/roles/spark/tasks/spark-worker.yml
@@ -16,5 +16,4 @@
     mode=0644
   notify:
     - reread supervisord
-    - restart spark worker
   tags: spark

--- a/roles/storm/handlers/main.yml
+++ b/roles/storm/handlers/main.yml
@@ -27,14 +27,17 @@
   wait_for: 
     port={{ nimbus_thrift_port }}
     state=started
+  when: storm_nimbus_enabled
 
 - name: wait for ui port
   wait_for: 
     port={{ storm_ui_port }}
     state=started
+  when: storm_ui_enabled
 
 - name: wait for logviewer port
   wait_for:
     port={{ storm_logviewer_port }}
     state=started
+  when: storm_logviewer_enabled
 

--- a/roles/storm/tasks/main.yml
+++ b/roles/storm/tasks/main.yml
@@ -92,11 +92,21 @@
     dest="{{ storm_install_dir }}/apache-storm-{{ storm_version }}/conf/storm.yaml"
     owner={{ storm_user }}
     group={{ storm_group }}
-    mode=644
+    mode=644    
+  register: storm_config
+  tags: storm
+  
+- name: restart storm to apply configuration changes
+  set_fact: storm_config_changed={{ storm_config.changed or (storm_config_changed is defined and storm_config_changed) }}
   notify:
     - restart storm nimbus
+    - wait for nimbus port
     - restart storm supervisor
     - restart storm ui
+    - wait for ui port
+    - restart storm logviewer
+    - wait for logviewer port
+  changed_when: storm_config_changed
   tags: storm
 
 - name: set storm file permissions

--- a/roles/storm/tasks/main.yml
+++ b/roles/storm/tasks/main.yml
@@ -100,11 +100,11 @@
   set_fact: storm_config_changed={{ storm_config.changed or (storm_config_changed is defined and storm_config_changed) }}
   notify:
     - restart storm nimbus
-    - wait for nimbus port
     - restart storm supervisor
     - restart storm ui
-    - wait for ui port
     - restart storm logviewer
+    - wait for nimbus port
+    - wait for ui port
     - wait for logviewer port
   changed_when: storm_config_changed
   tags: storm

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -210,6 +210,16 @@
     - deps-hbase
     - deps-spark
 
+- name: Hadoop Configuration Changed Fact Reset
+  hosts: hadoop-nodes
+  tasks:
+    - set_fact: hadoop_config_changed=false
+  tags:
+    - site-hadoop
+    - deps-hadoop
+    - deps-hbase
+    - deps-spark
+
 # --------------------------------- HBase ------------------------------------
 - name: HBase Master Node
   hosts: hbase-master-node
@@ -267,6 +277,14 @@
     - dfs_namenode_host: "{{ groups['hadoop-namenode-node'][0] }}"
     - yarn_historyserver_hostname: "{{ groups['hadoop-namenode-node'][0] }}"
   roles: [ spark ]
+  tags:
+    - site-spark
+    - deps-spark
+
+- name: Spark Configuration Changed Fact Reset
+  hosts: spark-nodes
+  tasks:
+    - set_fact: spark_config_changed=false
   tags:
     - site-spark
     - deps-spark

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -163,6 +163,14 @@
     - site-storm
     - deps-storm
 
+- name: Storm Configuration Changed Fact Reset
+  hosts: storm-nodes
+  tasks:
+    - set_fact: storm_config_changed=false
+  tags:
+    - site-storm
+    - deps-storm
+
 # --------------------------------- Hadoop -----------------------------------
 - name: HDFS Namenode
   hosts: hadoop-namenode-node


### PR DESCRIPTION
This corrects the execution behavior for handlers of roles that get multiple passes in the playbook.

The issue is that configuration changes get applied in the first execution of a role (i.e. hadoop namenode, or storm nimbus) triggering service restarts, but handlers in subsequent passes (i.e. datanodes or storm supervisors) residing on the same host as the initial role execution would not be triggered, because the configuration files were unchanged for that execution.

The solution is to use an ansible fact to record a configuration change happened, and to reset that state only after the role has entirely executed.
