### PR TITLE
Altered traptor to use virtualenv instead of miniconda

### DIFF
--- a/roles/traptor/defaults/main.yml
+++ b/roles/traptor/defaults/main.yml
@@ -2,7 +2,7 @@
 # Installation config
 traptor_name: traptor
 traptor_install_dir: "/opt/{{ traptor_name }}"
-traptor_miniconda_path: "{{ miniconda_install_dir|default('/opt/miniconda') }}/lib/python2.7/site-packages/{{ traptor_name }}"
+traptor_virtualenv_path: "{{ traptor_install_dir }}/venv"
 
 # Supervisor config
 traptor_num_procs: 1
@@ -21,6 +21,10 @@ traptor_kafka_topic: "traptor"
 traptor_type: "track"
 
 apikeys:
+  - consumer_key: ''
+    consumer_secret: ''
+    access_token: ''
+    access_token_secret: ''
   - consumer_key: ''
     consumer_secret: ''
     access_token: ''

--- a/roles/traptor/meta/main.yml
+++ b/roles/traptor/meta/main.yml
@@ -2,4 +2,4 @@
 dependencies:
   - { role: pip }
   - { role: supervisord }
-  - { role: miniconda }
+  - { role: virtualenv }

--- a/roles/traptor/tasks/main.yml
+++ b/roles/traptor/tasks/main.yml
@@ -1,24 +1,16 @@
 ---
-- name: Install Miniconda packages
-  shell: "{{ miniconda_install_dir|default('/opt/miniconda') }}/bin/conda install {{ item }} --yes"
-  with_items:
-    - pip
+- name: pip install traptor
+  pip:
+    virtualenv: "{{ traptor_virtualenv_path }}"
+    name: traptor
+    state: latest
   tags:
     - traptor
-    - miniconda
-
-- name: Miniconda pip install traptor
-  shell: "{{ miniconda_install_dir|default('/opt/miniconda') }}/bin/pip install traptor -U"
-  # notify:
-  #   - restart wat-scrapy-crawling
-  tags:
-    - traptor
-    - miniconda
 
 - name: create traptor symlink
   file:
-    src={{ traptor_miniconda_path }}
-    path={{ traptor_install_dir }}
+    src={{ traptor_virtualenv_path }}/lib/python2.7/site-packages/traptor/
+    path={{ traptor_install_dir }}/default
     state=link
     mode=0744
   tags: traptor
@@ -42,7 +34,7 @@
 - name: copy traptor settings
   template:
     src=localsettings.py.j2
-    dest={{ traptor_install_dir }}/localsettings.py
+    dest={{ traptor_install_dir }}/default/localsettings.py
     mode=0644
   notify:
     - restart traptor

--- a/roles/traptor/templates/traptor-supervisord.conf.j2
+++ b/roles/traptor/templates/traptor-supervisord.conf.j2
@@ -1,6 +1,7 @@
 [program:{{ traptor_name }}]
-command={{ miniconda_install_dir|default('/opt/miniconda') }}/bin/python {{ traptor_install_dir }}/traptor.py --info --delay=60
-directory={{ traptor_install_dir }}
+command=python {{ traptor_install_dir }}/default/traptor.py --info --delay=60
+environment=PATH="{{ traptor_virtualenv_path }}"
+directory={{ traptor_install_dir }}/default
 process_name=%(program_name)s
 numprocs={{ traptor_num_procs }}
 autostart=true

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -18,7 +18,9 @@
   hosts: all
   roles:
     - virtualenv
-  tags: virtual-env
+  tags:
+    - virtual-env
+    - deps-traptor
 
 - name: Run miniconda role
   hosts: all
@@ -26,7 +28,6 @@
     - miniconda
   tags:
     - miniconda
-    - deps-traptor
 
 # -------------------------- Zookeeper and Kafka -----------------------------
 - name: Run zookeeper role
@@ -106,6 +107,7 @@
   tags:
     - site-redis
     - scrapy-services
+    - deps-traptor
 
 - name: Run tor role
   hosts: tor-proxy


### PR DESCRIPTION
If this works we should be using the `pip` virtualenv directive more often. Also added Redis as a deps, and removed miniconda as a meta dependency. Updated sueprvisord configs too.

To test:
- fill in API keys if applicable in your group_vars (otherwise traptor will run but just log an error

`ansible-playbook site-infrastructure.yml --tags deps-traptor -u vagrant`

Tagging @jasonrhaas 
