### PR TITLE
Add elasticsearch-hadoop role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vagrant
 id_rsa.pub
 vault.passwd
+*.retry
 
 # docs
 _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
   - TAGS='site-tangelo'
   - TAGS='mysql'
   - TAGS='deps-traptor'
+  - TAGS='site-es-hadoop'
 
 matrix:
   fast_finish: true

--- a/roles/es-hadoop/defaults/main.yml
+++ b/roles/es-hadoop/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+
+es_hadoop_install_dir: /opt/elasticsearch-hadoop
+es_hadoop_version: 2.2.0
+
+repository_infrastructure:  "http://download.elastic.co/hadoop"

--- a/roles/es-hadoop/tasks/main.yml
+++ b/roles/es-hadoop/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+
+- name: Install unzip
+  apt:
+    name: unzip
+    state: present
+  tags: es-hadoop
+
+- name: create es-hadoop install directory
+  file:
+    path={{ es_hadoop_install_dir }}/
+    state=directory
+    mode=0744
+  tags: es-hadoop
+
+- name: check for existing es-hadoop install
+  stat: path={{ es_hadoop_install_dir }}/elasticsearch-hadoop-{{ es_hadoop_version }}
+  register: es_hadoop
+  tags: es-hadoop
+
+- name: download es-hadoop
+  get_url:
+    validate_certs=no
+    url={{ repository_infrastructure }}/elasticsearch-hadoop-{{ es_hadoop_version }}.zip
+    dest=/tmp/elasticsearch-hadoop-{{ es_hadoop_version }}.zip
+    mode=0644
+  when: es_hadoop.stat.isdir is not defined
+  tags: es-hadoop
+
+- name: extract es-hadoop
+  unarchive:
+    src=/tmp/elasticsearch-hadoop-{{ es_hadoop_version }}.zip
+    dest={{ es_hadoop_install_dir }}/
+    copy=no
+  when: es_hadoop.stat.isdir is not defined
+  tags: es-hadoop
+
+- name: delete temporary es-hadoop file
+  file:
+    path=/tmp/elasticsearch-hadoop-{{ es_hadoop_version }}.zip
+    state=absent
+  ignore_errors: yes
+  tags: es-hadoop
+
+- name: Change es-hadoop permissions
+  file:
+    path={{ es_hadoop_install_dir }}
+    mode=0755
+  tags: es-hadoop
+
+- name: create default symlink
+  file:
+    path={{ es_hadoop_install_dir }}/default
+    state=link
+    src={{ es_hadoop_install_dir }}/elasticsearch-hadoop-{{ es_hadoop_version }}
+  tags: es-hadoop

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -100,6 +100,14 @@
     - site-kibana
     - ELK
 
+# --------------------------- Elasticsearch Hadoop ---------------------------
+
+- name: Elasticsearch Hadoop connector
+  hosts: hadoop-nodes
+  roles: [ es-hadoop ]
+  tags:
+    - site-es-hadoop
+
 # --------------------------- Scraper services -------------------------------
 - name: Run redis role
   hosts: redis-nodes


### PR DESCRIPTION
By default the **elasticsearch-hadoop** connector gets installed on all the `hadoop-nodes` in the `/opt/elasticsearch-hadoop/` location
