### PR TITLE
Upgrade ELK, add Timelion

### DIFF
--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -3,7 +3,7 @@
 elasticsearch_install_dir: /opt/elasticsearch
 elasticsearch_user: elasticsearch
 elasticsearch_group: elasticsearch
-elasticsearch_version: 2.2.0
+elasticsearch_version: 2.3.0
 elasticsearch_max_open_files: 65535
 elasticsearch_max_locked_memory: 100000
 elasticsearch_max_num_procs: 32000

--- a/roles/kibana4/defaults/main.yml
+++ b/roles/kibana4/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
 kibana4_install_dir: /opt/kibana4
-kibana4_version: 4.4.0-linux-x64
+kibana4_version: 4.5.0-linux-x64
 kibana4_port: 5601
 kibana4_index: ".kibana"
 kibana4_request_timeout: 300000
 kibana4_verify_ssl: false
 kibana4_stderr_logfile_maxbytes: 50MB
+kibana4_install_timelion: True
 
 repository_infrastructure: "https://download.elastic.co/kibana/kibana"

--- a/roles/kibana4/tasks/main.yml
+++ b/roles/kibana4/tasks/main.yml
@@ -80,4 +80,19 @@
   tags:
     - kibana4
 
+- name: check for existing timelion plugin install
+  stat:
+    path: "{{ kibana4_install_dir }}/default/installedPlugins/timelion"
+  register: kibanatimelion
+  when: kibana4_install_timelion
+  tags:
+    - kibana4
+
+- name: install timelion plugin
+  shell: "{{ kibana4_install_dir }}/default/bin/kibana plugin -i kibana/timelion"
+  when: kibana4_install_timelion and kibanatimelion.stat.isdir is not defined
+  notify:
+    - restart kibana4
+  tags:
+    - kibana4
 

--- a/roles/logstash/defaults/main.yml
+++ b/roles/logstash/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 logstash_install_dir: /opt/logstash
-logstash_version: 2.2.0
+logstash_version: 2.3.0
 logstash_conf_dir: /etc/logstash.d
 logstash_template_dir: "{{ logstash_conf_dir }}/templates"
 logstash_sincedb_dir: "{{ logstash_install_dir }}/.sincedb"


### PR DESCRIPTION
Bumps the ELK stack to the latest release

To test from a blank machine:
`$ ansible-playbook site-infrastructure.yml --tags site-elasticsearch,site-kibana -u vagrant`

Then in a browser go to `vagrant-as-01:5601` to load Kibana. In the top black bar next to `Settings` you should see a new icon that allows you to select the Timelion plugin to do analysis. No further testing was done of Timelion, other than that it installs properly.
