### PR TITLE
Add Tarsnap role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
   - TAGS='mysql'
   - TAGS='deps-traptor'
   - TAGS='site-es-hadoop'
+  - TAGS='site-tarsnap'
 
 matrix:
   fast_finish: true

--- a/roles/tarsnap/defaults/main.yml
+++ b/roles/tarsnap/defaults/main.yml
@@ -1,0 +1,64 @@
+---
+# file: roles/tarsnap/defaults/main.yml
+
+###################################################
+# Basic vars
+###################################################
+tarsnap_version: 1.0.37
+
+# Retrieve SHA256 from:
+# https://www.tarsnap.com/download/tarsnap-sigs-1.0.37.asc (replace version number)
+tarsnap_tar_sha256: fa999413651b3bd994547a10ffe3127b4a85a88b1b9a253f2de798888718dbfa
+
+tarsnap_cron:
+  minute: "19"
+  hour: "*/8"
+  day_of_month: "*"
+  month: "*"
+  day_of_week: "*"
+
+tarsnap_num_backups:
+  hourly: 36
+  daily: 30
+  weekly: 8
+  monthly: 24
+
+tarsnap_backup_dirs:
+  - /home
+  - /etc
+  - /var
+  - /opt
+  - /root
+
+###################################################
+# Tarsnap configuration directives
+###################################################
+tarsnap_conf_keyfile_path: "{{ tarsnap_install_dir }}/tarsnap.key"
+tarsnap_conf_cache_dir: "{{ tarsnap_install_dir }}/tarsnap-cache"
+tarsnap_conf_no_dump: true
+tarsnap_conf_stat_print_style: "humanize-numbers"
+tarsnap_conf_checkpoint_bytes: "1G"
+tarsnap_conf_aggressive_networking: false
+tarsnap_conf_exclude_dirs:
+    - scratch/
+    - etc/ssh/certs/
+tarsnap_conf_include_dirs: []
+tarsnap_conf_mem_level: null
+tarsnap_conf_snaptime_file: null
+
+###################################################
+# Installation location vars
+###################################################
+tarsnap_install_dir: /opt/tarsnap
+tarsnap_previous_key_dir: /root
+tarsnap_source_dir: "{{ tarsnap_install_dir }}/tarsnap-autoconf-{{ tarsnap_version }}"
+tarsnap_config_path: "{{ tarsnap_source_dir }}/etc/tarsnap.conf"
+tarsnap_folders_list: "{{ tarsnap_install_dir }}/tarsnap.folders"
+
+tarsnap_default_symlink_path: "{{ tarsnap_install_dir }}/default"
+tarsnap_executable_dir: "{{ tarsnap_default_symlink_path }}/bin"
+tarsnap_executable_symlink_dest: "/usr/bin"
+
+tarsnap_config_dir: "{{ tarsnap_default_symlink_path }}/etc"
+
+tarsnap_config_symlink: /etc/tarsnap

--- a/roles/tarsnap/tasks/main.yml
+++ b/roles/tarsnap/tasks/main.yml
@@ -1,0 +1,183 @@
+---
+# file: roles/tarsnap/tasks/main.yml
+
+# Tarsnap installation instructions:
+# https://www.tarsnap.com/compiling.html
+# https://www.tarsnap.com/gettingstarted.html
+
+- name: Determine if tarsnap {{ tarsnap_version }} is installed
+  command: tarsnap --version
+  register: tarsnap_version_cmd
+
+  # Some older versions of tarsnap (incorrectly) use an exit code of 1 for
+  # `$ tarsnap  --version`. Thus the command module throwing a failure here
+  # doesn't necessarily mean the `tarsnap` command does not exist, the host may
+  # just have an older version of tarsnap.
+  failed_when: false
+  changed_when: false
+  tags:
+    - tarsnap
+    - tarsnap-install
+    - tarsnap-genkey
+    - tarsnap-conf
+
+- name: Determine if tarsnap is managed by Ansible
+  stat: path={{ tarsnap_default_symlink_path }}
+  register: tarsnap_symlink
+  tags:
+    - tarsnap
+    - tarsnap-install
+    - tarsnap-genkey
+    - tarsnap-conf
+
+###################################################
+# Install tarsnap
+###################################################
+- block:
+    - include: setup-{{ ansible_os_family}}.yml
+
+    - name: Create tarsnap installation directory
+      file:
+        path={{ tarsnap_install_dir }}
+        state=directory
+
+    - name: Download tarsnap tar
+      get_url:
+        url=https://www.tarsnap.com/download/tarsnap-autoconf-{{ tarsnap_version }}.tgz
+        dest={{ tarsnap_install_dir }}/tarsnap-autoconf-{{ tarsnap_version }}.tgz
+        checksum=sha256:{{ tarsnap_tar_sha256 }}
+
+    - name: Untar tarsnap
+      unarchive:
+        src={{ tarsnap_source_dir }}.tgz
+        dest={{ tarsnap_install_dir }}
+        copy=no
+
+    - name: Download Tarsnap-Generations script
+      get_url:
+        url=https://raw.githubusercontent.com/Gestas/Tarsnap-generations/029d130e6e7efa5f0ad1238667349d88d97b485a/tarsnap-generations.sh
+        dest={{ tarsnap_install_dir }}/tarsnap-generations.sh
+        mode=744
+
+    - name: Create default tarsnap symlink
+      file:
+        src={{ tarsnap_source_dir }}
+        dest={{ tarsnap_default_symlink_path }}
+        state=link
+
+    - name: Retrieve tarsnap executable filenames
+      find: paths={{ tarsnap_executable_dir }}
+      register: tarsnap_executable_dir_files
+
+    # Only compile if this hasn't been built yet (as indicated by no executable
+    # files found)
+    - name: Build tarsnap from source
+      command: "{{ item }}"
+      args:
+        chdir: "{{ tarsnap_source_dir }}"
+      with_items:
+        - ./configure --prefix={{ tarsnap_source_dir }}
+        - make install
+      when: tarsnap_executable_dir_files.matched == 0
+
+    - name: Create PATH-accessible symlinks to tarsnap executables
+      file:
+        src={{ tarsnap_default_symlink_path }}/bin/{{ item.path|basename }}
+        dest={{ tarsnap_executable_symlink_dest }}/{{ item.path|basename }}
+        state=link
+      with_items: "{{ tarsnap_executable_dir_files.files }}"
+
+  # Use |default to prevent KeyError in the case stdout doesn't exist (which
+  # implies the tarsnap command was not on the host at all)
+  when:
+    tarsnap_version_cmd.stdout|default("") != "tarsnap {{ tarsnap_version }}" or
+    tarsnap_symlink.stat.islnk is not defined
+  tags:
+    - tarsnap
+    - tarsnap-install
+
+###################################################
+# Move/Generate tarsnap keys
+###################################################
+- block:
+    # Previous installations of tarsnap existed at /root.
+    - name: Find existing tarsnap key
+      find:
+          paths:
+            - "{{ tarsnap_previous_key_dir }}/"
+            - "{{ tarsnap_install_dir }}/"
+          patterns: "*tarsnap*.key"
+      register: tarsnap_key
+
+    - name: Rename tarsnap key if it exists
+      command:
+        mv "{{ (tarsnap_key.files|first).path }}" "{{ tarsnap_conf_keyfile_path }}"
+        creates="{{ tarsnap_conf_keyfile_path }}"
+      when: tarsnap_key.matched == 1
+
+    - name: Generate tarsnap key if it does not exist
+      shell: "{{ tarsnap_executable_dir }}/tarsnap-keygen --keyfile {{ tarsnap_conf_keyfile_path }} --user {{ tarsnap_credentials.username }} --machine {{ ansible_nodename}} <<< {{ tarsnap_credentials.password }}"
+      args:
+        executable: /bin/bash # required for <<< syntax
+      when: tarsnap_key.matched == 0 and tarsnap_credentials is defined
+  tags:
+    - tarsnap
+    - tarsnap-genkey
+
+###################################################
+# Configuration / Cron
+###################################################
+- block:
+    - name: Copy tarsnap configuration file
+      template:
+        src=tarsnap.conf.j2
+        dest={{ tarsnap_config_path }}
+        mode=0644
+
+    - name: Create tarsnap configuration directory symlink
+      file:
+        src={{ tarsnap_config_dir }}
+        dest={{ tarsnap_config_symlink }}
+        state=link
+
+    - name: Create tarsnap cache directory
+      file:
+        path={{ tarsnap_conf_cache_dir }}
+        state=directory
+
+    - name: Remove pre-ansible Tarsnap-Generations crontab entry
+      lineinfile:
+        regexp="tarsnap-generations"
+        dest=/etc/crontab
+        state=absent
+
+    - name: Populate tarsnap backup folders list
+      lineinfile:
+        dest={{ tarsnap_folders_list }}
+        state=present
+        create=yes
+        line={{ item }}
+      with_items: "{{ tarsnap_backup_dirs }}"
+
+    - name: Create Tarsnap-Generations crontab entry
+      cron:
+        name: "Tarsnap backup via Tarsnap-Generations"
+        cron_file: tarsnap
+        user: root
+        minute: "{{ tarsnap_cron.minute }}"
+        hour: "{{ tarsnap_cron.hour }}"
+        day: "{{ tarsnap_cron.day_of_month }}"
+        month: "{{ tarsnap_cron.month }}"
+        weekday: "{{ tarsnap_cron.day_of_week }}"
+        job:
+            nice -n 20 {{ tarsnap_install_dir }}/tarsnap-generations.sh
+            -f {{ tarsnap_folders_list }}
+            -h {{ tarsnap_num_backups.hourly }}
+            -d {{ tarsnap_num_backups.daily }}
+            -w {{ tarsnap_num_backups.weekly }}
+            -m {{ tarsnap_num_backups.monthly }}
+            -q
+      when: tarsnap_credentials is defined
+  tags:
+    - tarsnap
+    - tarsnap-conf

--- a/roles/tarsnap/tasks/setup-Debian.yml
+++ b/roles/tarsnap/tasks/setup-Debian.yml
@@ -1,0 +1,12 @@
+---
+- name: Install tarsnap required packages via apt
+  apt:
+    name={{ item }}
+    state=latest
+  with_items:
+    - gcc
+    - libc6-dev
+    - make
+    - libssl-dev
+    - zlib1g-dev
+    - e2fslibs-dev

--- a/roles/tarsnap/tasks/setup-RedHat.yml
+++ b/roles/tarsnap/tasks/setup-RedHat.yml
@@ -1,0 +1,12 @@
+---
+- name: Install tarsnap required packages via yum
+  yum:
+    name={{ item }}
+    state=latest
+  with_items:
+    - gcc
+    - make
+    - glibc-devel
+    - openssl-devel
+    - zlib-devel
+    - e2fsprogs-devel

--- a/roles/tarsnap/templates/tarsnap.conf.j2
+++ b/roles/tarsnap/templates/tarsnap.conf.j2
@@ -1,0 +1,66 @@
+# **********************************
+# Managed by Ansible
+# **********************************
+
+# Tarsnap cache directory
+cachedir {{ tarsnap_conf_cache_dir }}
+
+# Tarsnap key file
+keyfile {{ tarsnap_conf_keyfile_path }}
+
+# Don't archive files which have the nodump flag set
+{% if not tarsnap_conf_no_dump %}#{% endif %}nodump
+
+# Print statistics when creating or deleting archives
+# OPTIONS:
+#   print-stats
+#   humanize-numbers
+#   quiet
+{{ tarsnap_conf_stat_print_style }}
+
+# Create a checkpoint once per GB of uploaded data.
+checkpoint-bytes {{ tarsnap_conf_checkpoint_bytes }}
+
+### Other options, not applicable to most systems
+
+# Aggressive network behaviour: Use multiple TCP connections when
+# writing archives.  Use of this option is recommended only in
+# cases where TCP congestion control is known to be the limiting
+# factor in upload performance.
+
+{% if not tarsnap_conf_aggressive_networking %}#{% endif %}aggressive-networking
+
+# Exclude files and directories matching specified patterns
+{% for excluded_dir in tarsnap_conf_exclude_dirs %}
+exclude {{ excluded_dir }}
+{% endfor %}
+
+# Include only files and directories matching specified patterns
+{% for included_dir in tarsnap_conf_include_dirs %}
+include {{ included_dir }}
+{% endfor %}
+
+# (Optional) Attempt to reduce tarsnap memory consumption.
+# OPTIONS:
+#   (blank)
+#   lowmem
+#   verylowmem
+#
+# lowmem
+# will slow down the process of creating archives, but may help
+# on systems where the average size of files being backed up is
+# less than 1 MB.
+#
+#verylowmem
+# Try even harder to reduce tarsnap memory consumption.  This can
+# significantly slow down tarsnap, but reduces its memory usage
+# by an additional factor of 2 beyond what the lowmem option does.
+{{ tarsnap_conf_mem_level|default("") }}
+
+# Snapshot time.  Use this option if you are backing up files
+# from a filesystem snapshot rather than from a "live" filesystem.
+{% if tarsnap_conf_snaptime_file %}
+snaptime {{ tarsnap_conf_snaptime_file }}
+{% else %}
+# snaptime <file>
+{% endif %}

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -364,3 +364,11 @@
   tags:
     - site-traptor
     - deps-traptor
+
+# ---------------------------------- Tarsnap --------------------------------
+
+- name: Tarsnap
+  hosts: tarsnap-nodes
+  roles: [ tarsnap ]
+  tags:
+    - site-tarsnap

--- a/testing.inventory
+++ b/testing.inventory
@@ -156,3 +156,6 @@ travis-trusty
 
 [mysql-node]
 travis-trusty
+
+[tarsnap-nodes]
+travis-trusty


### PR DESCRIPTION
Adds [Tarsnap](https://www.tarsnap.com/) backup functionality to your servers!
## Details

This role installs Tarsnap from source (as Tarsnap does not distribute binaries), allows you to easily specify what directories you would like backed up, how many backups you would like to retain, and how often you would like tarsnap to run via cron.
## Usage

To have your servers backed up via the tarsnap role, you must:

1) Create an account on  [Tarsnap](https://www.tarsnap.com/)
2) Define a `tarsnap_credentials` variable in the form

```
tarsnap_credentials:
  username: "YourTarsnapUsername"
  password: "YourTarsnapPassword"
```
## Running the Tarsnap role

To run the tarsnap role, execute the following. (You must manually populate `staging.inventory` with a `[tarsnap-nodes]` group. Since backups cost money, we don't include this role by default)

```
$ ansible-playbook -i staging.inventory -u vagrant --tags="site-tarsnap" site-infrastructure.yml
```
