### PR TITLE
Update to how Traptor deployment works

### DIFF
--- a/roles/traptor/defaults/main.yml
+++ b/roles/traptor/defaults/main.yml
@@ -8,7 +8,6 @@ traptor_miniconda_path: "/opt/miniconda/envs/traptor/lib/python2.7/site-packages
 miniconda_install_dir: "/opt/miniconda"
 
 # Supervisor config
-traptor_num_procs: 1
 traptor_start_secs: 5
 traptor_start_retries: 100
 traptor_stderr_logfile_maxbytes: 50MB
@@ -19,15 +18,30 @@ traptor_log_file: "{{ traptor_name }}.log"
 traptor_log_max_bytes: 25000000
 traptor_log_backups: 5
 
+traptor_track_count: 2
+traptor_follow_count: 1
+traptor_location_count: 1
+
 # Traptor localsettings.py
 traptor_kafka_topic: "traptor"
-traptor_type: "track"
 
-apikeys:
+traptor_track_apikeys:
+  - consumer_key: 'a'
+    consumer_secret: 'a'
+    access_token: 'a'
+    access_token_secret: 'a'
+  - consumer_key: 'b'
+    consumer_secret: 'b'
+    access_token: 'b'
+    access_token_secret: 'b'
+
+traptor_follow_apikeys:
   - consumer_key: ''
     consumer_secret: ''
     access_token: ''
     access_token_secret: ''
+
+traptor_location_apikeys:
   - consumer_key: ''
     consumer_secret: ''
     access_token: ''

--- a/roles/traptor/handlers/main.yml
+++ b/roles/traptor/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: restart traptor
   supervisorctl:
-    name={{ traptor_name }}
+    name="{{ traptor_name }}:"
     state=restarted

--- a/roles/traptor/templates/localsettings.py.j2
+++ b/roles/traptor/templates/localsettings.py.j2
@@ -5,45 +5,46 @@ REDIS_HOST = "{{ groups['redis-master-node'][0] }}"
 REDIS_PORT = {{ traptor_redis_port }}
 REDIS_DB = {{ traptor_redis_db }}
 
-{% if inventory_hostname in groups['traptor-follow-nodes'] %}
-# Twitter Streaming API 'follow'
-{% for host in groups['traptor-follow-nodes'] %}
-{%- if host == inventory_hostname -%}
-
-TRAPTOR_ID = {{ loop.index - 1}}
-{%- endif -%}
-{% endfor %}
-
-TRAPTOR_TYPE = 'follow'
-{% endif %}
-
-
-{% if inventory_hostname in groups['traptor-track-nodes'] %}
-# Twitter Streaming API 'track'
-{% for host in groups['traptor-track-nodes'] %}
-{%- if host == inventory_hostname -%}
-
-TRAPTOR_ID = {{ loop.index - 1}}
-{%- endif -%}
-{% endfor %}
-
-TRAPTOR_TYPE = 'track'
-{% endif %}
-
 KAFKA_TOPIC = "{{ traptor_kafka_topic }}"
 
 # Twitter API Keys
-{% for host in groups['traptor-nodes'] %}
-{% if loop.index <= groups['traptor-nodes'] | length %}
-{%- if host == inventory_hostname -%}
+{% if inventory_hostname in groups['traptor-track-nodes'] %}
 APIKEYS = (
+{% for key in traptor_track_apikeys %}
     {
-        'CONSUMER_KEY': "{{ apikeys[loop.index - 1]['consumer_key'] }}",
-        'CONSUMER_SECRET': "{{ apikeys[loop.index - 1]['consumer_secret'] }}",
-        'ACCESS_TOKEN': "{{ apikeys[loop.index - 1]['access_token'] }}",
-        'ACCESS_TOKEN_SECRET': "{{ apikeys[loop.index - 1]['access_token_secret'] }}"
+        'CONSUMER_KEY': "{{ traptor_track_apikeys[loop.index - 1]['consumer_key'] }}",
+        'CONSUMER_SECRET': "{{ traptor_track_apikeys[loop.index - 1]['consumer_secret'] }}",
+        'ACCESS_TOKEN': "{{ traptor_track_apikeys[loop.index - 1]['access_token'] }}",
+        'ACCESS_TOKEN_SECRET': "{{ traptor_track_apikeys[loop.index - 1]['access_token_secret'] }}"
     },
-)
-{%- endif -%}
-{% endif %}
 {% endfor %}
+)
+{% endif %}
+
+
+{% if inventory_hostname in groups['traptor-follow-nodes'] %}
+APIKEYS = (
+{% for key in groups['traptor-follow-nodes'] %}
+    {
+        'CONSUMER_KEY': "{{ traptor_follow_apikeys[loop.index - 1]['consumer_key'] }}",
+        'CONSUMER_SECRET': "{{ traptor_follow_apikeys[loop.index - 1]['consumer_secret'] }}",
+        'ACCESS_TOKEN': "{{ traptor_follow_apikeys[loop.index - 1]['access_token'] }}",
+        'ACCESS_TOKEN_SECRET': "{{ traptor_follow_apikeys[loop.index - 1]['access_token_secret'] }}"
+    },
+{% endfor %}
+)
+{% endif %}
+
+
+{% if inventory_hostname in groups['traptor-location-nodes'] %}
+APIKEYS = (
+{% for key in groups['traptor-location-nodes'] %}
+    {
+        'CONSUMER_KEY': "{{ traptor_location_apikeys[loop.index - 1]['consumer_key'] }}",
+        'CONSUMER_SECRET': "{{ traptor_location_apikeys[loop.index - 1]['consumer_secret'] }}",
+        'ACCESS_TOKEN': "{{ traptor_location_apikeys[loop.index - 1]['access_token'] }}",
+        'ACCESS_TOKEN_SECRET': "{{ traptor_location_apikeys[loop.index - 1]['access_token_secret'] }}"
+    },
+{% endfor %}
+)
+{% endif %}

--- a/roles/traptor/templates/traptor-supervisord.conf.j2
+++ b/roles/traptor/templates/traptor-supervisord.conf.j2
@@ -1,8 +1,9 @@
-[program:{{ traptor_name }}]
-command={{ traptor_miniconda_env }}/bin/python {{ traptor_install_dir }}/default/traptor.py --info --delay=5
+{% if inventory_hostname in groups['traptor-track-nodes'] %}
+[program:traptor_track]
+command={{ traptor_miniconda_env }}/bin/python {{ traptor_install_dir }}/default/traptor.py --info --delay=5 --type=track --key=%(process_num)02d --id=%(process_num)02d
 directory={{ traptor_install_dir }}/default
-process_name=%(program_name)s
-numprocs={{ traptor_num_procs }}
+process_name=%(process_num)02d
+numprocs={{ traptor_track_count }}
 autostart=true
 autorestart=true
 exitcodes=0,2,3
@@ -12,3 +13,40 @@ stopsignal=KILL
 redirect_stderr=true
 stderr_logfile=AUTO
 stderr_logfile_maxbytes={{ traptor_stderr_logfile_maxbytes }}
+{% endif %}
+
+{% if inventory_hostname in groups['traptor-follow-nodes'] %}
+[program:traptor_follow]
+command={{ traptor_miniconda_env }}/bin/python {{ traptor_install_dir }}/default/traptor.py --info --delay=5 --type=follow --key=%(process_num)02d --id=%(process_num)02d
+directory={{ traptor_install_dir }}/default
+process_name=%(process_num)02d
+numprocs={{ traptor_follow_count }}
+autostart=true
+autorestart=true
+exitcodes=0,2,3
+startsecs={{ traptor_start_secs }}
+startretries={{ traptor_start_retries }}
+stopsignal=KILL
+redirect_stderr=true
+stderr_logfile=AUTO
+stderr_logfile_maxbytes={{ traptor_stderr_logfile_maxbytes }}
+{% endif %}
+
+{% if inventory_hostname in groups['traptor-location-nodes'] %}
+[program:traptor_location]
+command={{ traptor_miniconda_env }}/bin/python {{ traptor_install_dir }}/default/traptor.py --info --delay=5 --type=location --key=%(process_num)02d --id=%(process_num)02d
+directory={{ traptor_install_dir }}/default
+process_name=%(process_num)02d
+numprocs={{ traptor_location_count }}
+autostart=true
+autorestart=true
+exitcodes=0,2,3
+startsecs={{ traptor_start_secs }}
+startretries={{ traptor_start_retries }}
+stopsignal=KILL
+redirect_stderr=true
+stderr_logfile=AUTO
+stderr_logfile_maxbytes={{ traptor_stderr_logfile_maxbytes }}
+{% endif %}
+
+

--- a/roles/traptor/templates/traptor-supervisord.conf.j2
+++ b/roles/traptor/templates/traptor-supervisord.conf.j2
@@ -1,8 +1,8 @@
 {% if inventory_hostname in groups['traptor-track-nodes'] %}
-[program:traptor_track]
+[program:traptor]
 command={{ traptor_miniconda_env }}/bin/python {{ traptor_install_dir }}/default/traptor.py --info --delay=5 --type=track --key=%(process_num)02d --id=%(process_num)02d
 directory={{ traptor_install_dir }}/default
-process_name=%(process_num)02d
+process_name=track_%(process_num)02d
 numprocs={{ traptor_track_count }}
 autostart=true
 autorestart=true
@@ -16,10 +16,10 @@ stderr_logfile_maxbytes={{ traptor_stderr_logfile_maxbytes }}
 {% endif %}
 
 {% if inventory_hostname in groups['traptor-follow-nodes'] %}
-[program:traptor_follow]
+[program:traptor]
 command={{ traptor_miniconda_env }}/bin/python {{ traptor_install_dir }}/default/traptor.py --info --delay=5 --type=follow --key=%(process_num)02d --id=%(process_num)02d
 directory={{ traptor_install_dir }}/default
-process_name=%(process_num)02d
+process_name=follow_%(process_num)02d
 numprocs={{ traptor_follow_count }}
 autostart=true
 autorestart=true
@@ -33,10 +33,10 @@ stderr_logfile_maxbytes={{ traptor_stderr_logfile_maxbytes }}
 {% endif %}
 
 {% if inventory_hostname in groups['traptor-location-nodes'] %}
-[program:traptor_location]
+[program:traptor]
 command={{ traptor_miniconda_env }}/bin/python {{ traptor_install_dir }}/default/traptor.py --info --delay=5 --type=location --key=%(process_num)02d --id=%(process_num)02d
 directory={{ traptor_install_dir }}/default
-process_name=%(process_num)02d
+process_name=location_%(process_num)02d
 numprocs={{ traptor_location_count }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
Several changes were made to how Traptor is deployed to allow for more
flexibility and scalability:
- Specific traptor process config options are moved out of settings.py
  and into the command line arguments and supervisord configs.
- One machine is used for each traptor type.  track, follow, location
- Can have an arbitrary number of traptors on each machine.
- Number of traptor processes per type is set as an Ansible variable.
  For example, `traptor_track_count`.
- API keys are grouped into the different types.  You must have as many
  API keys as you do traptors for each type.
