### PR TITLE
Added steps to configure snappy compression for hbase

### DIFF
--- a/roles/hbase/defaults/main.yml
+++ b/roles/hbase/defaults/main.yml
@@ -40,4 +40,8 @@ hbase_thriftserver_port: 9090
 hbase_thriftserver_info_port: 9095
 hbase_jmx_remote_port: 10102
 
+hbase_snappy_compression: true
+hbase_native_arch: Linux-amd64-64
+hbase_native_arch_dir: "{{ hbase_install_dir }}/default/lib/native/{{ hbase_native_arch }}"
+
 repository_infrastructure: "{{ apache_mirror }}/hbase/{{ hbase_version }}"

--- a/roles/hbase/tasks/hbase-snappy.yml
+++ b/roles/hbase/tasks/hbase-snappy.yml
@@ -1,0 +1,37 @@
+---
+- name: install snappy compression
+  apt:
+    name={{ item }}
+    state=latest
+  with_items:
+   - libsnappy1
+  tags: 
+   - hbase
+   - snappy
+   
+- name: create hbase native lib directory
+  file:
+    path: "{{ hbase_native_arch_dir }}"
+    state: directory
+    mode: 0744
+    owner: "{{ hbase_user }}"
+    group: "{{ hbase_group }}"
+  tags: 
+   - hbase
+   - snappy
+  
+- name: create native lib symlinks
+  file:
+    path: "{{ item.path }}"
+    src: "{{ item.src }}"
+    state: link
+    mode: 0744
+    owner: "{{ hbase_user }}"
+    group: "{{ hbase_group }}"
+  with_items:
+    - { path: "{{ hbase_native_arch_dir }}/libhadoop.so", src: "{{ hdfs_install_dir|default('/opt/hadoop') }}/default/lib/native/libhadoop.so" }
+    - { path: "{{ hbase_native_arch_dir }}/libsnappy.so", src: "/usr/lib/libsnappy.so.1" }
+  tags: 
+   - hbase
+   - snappy
+  

--- a/roles/hbase/tasks/main.yml
+++ b/roles/hbase/tasks/main.yml
@@ -42,7 +42,7 @@
 - name: download hbase
   get_url:
     url: "{{ repository_infrastructure }}/hbase-{{ hbase_version }}-bin.tar.gz"
-    dest: /tmp/hbase-{{ hbase_version }}.tgz
+    dest: "/tmp/hbase-{{ hbase_version }}.tgz"
     mode: 0644
     validate_certs: no
   when: hbase.stat.isdir is not defined
@@ -50,7 +50,7 @@
 
 - name: extract hbase
   unarchive:
-    src: /tmp/hbase-{{ hbase_version }}.tgz
+    src: "/tmp/hbase-{{ hbase_version }}.tgz"
     dest: "{{ hbase_install_dir }}"
     copy: no
     owner: "{{ hbase_user }}"
@@ -60,7 +60,7 @@
 
 - name: delete temporary hbase file
   file:
-    path: /tmp/hbase-{{ hbase_version }}.tgz
+    path: "/tmp/hbase-{{ hbase_version }}.tgz"
     state: absent
   ignore_errors: yes
   tags: hbase
@@ -68,19 +68,29 @@
 - name: create hbase symlink
   file:
     path: "{{ hbase_install_dir }}/default"
-    state: link
     src: "{{ hbase_install_dir }}/hbase-{{ hbase_version }}"
+    state: link
+    owner: "{{ hbase_user }}"
+    group: "{{ hbase_group }}"
   tags: hbase
 
 - name: configure *-site.xml files
   template:
-    src={{ item }}
-    dest="{{ hbase_install_dir }}/default/conf/{{ item | regex_replace('.j2', '') }}"
-    mode=0644
+    src: "{{ item }}"
+    dest: "{{ hbase_install_dir }}/default/conf/{{ item | regex_replace('.j2', '') }}"
+    mode: 0644
   with_items:
     - hbase-site.xml.j2
     - hbase-env.sh.j2
   register: hbase_config
+  tags: hbase
+
+- name: ensure hbase file ownership
+  file:
+    path: "{{ hbase_install_dir }}/"
+    recurse: yes
+    owner: "{{ hbase_user }}"
+    group: "{{ hbase_group }}"
   tags: hbase
   
 - name: restart hbase to apply configuration changes
@@ -97,9 +107,9 @@
     
 - name: set ulimit hbase configuration
   template:
-    src=hbase.conf.j2
-    dest=/etc/security/limits.d/hbase.conf
-    mode=0755
+    src: hbase.conf.j2
+    dest: "/etc/security/limits.d/hbase.conf"
+    mode: 0755
   tags: hbase
 
 - name: Configuring open file limits
@@ -113,11 +123,11 @@
 
 - name: create data directories
   file:
-    path={{ item }}
-    state=directory
-    mode=0755
-    owner=hbase
-    group=hbase
+    path: "{{ item }}"
+    state: directory
+    mode: 0755
+    owner: "{{ hbase_user }}"
+    group: "{{ hbase_group }}"
   with_items:
     - "{{ hbase_tmp_dir }}"
   tags:
@@ -128,6 +138,19 @@
     dest: /etc/environment
     line: "export LD_LIBRARY_PATH={{ hdfs_install_dir|default('/opt/hadoop') }}/default/lib"
   tags: hadoop
+
+- include: hbase-snappy.yml
+  when: hbase_snappy_compression and (hbase_master_enabled or hbase_regionserver_enabled)
+  notify:
+    - restart hbase master
+    - wait for hbase master port
+    - restart hbase region server
+    - wait for hbase region server port
+  tags:
+    - hbase
+    - hbase_master
+    - hbase_regionserver
+    - snappy
 
 - include: hbase-master.yml
   when: hbase_master_enabled

--- a/roles/hbase/templates/hbase-site.xml.j2
+++ b/roles/hbase/templates/hbase-site.xml.j2
@@ -96,5 +96,17 @@
     <name>hbase.zookeeper.property.clientPort</name>
     <value>{{ zookeeper_client_port|default(2181) }}</value>
   </property>
+  
+{% if hbase_snappy_compression %}
+  <property>
+    <name>hbase.master.check.compression</name>
+    <value>true</value>
+  </property>
 
+  <property>
+    <name>hbase.regionserver.codecs</name>
+    <value>snappy</value>
+  </property>
+  
+{% endif %}
 </configuration>


### PR DESCRIPTION
Ansible will now install and configure [Snappy](http://google.github.io/snappy/) compression for use in HBase. This is a configuration change and will restart both hbase master and all hbase region servers.

Compression must still be enabled per column family for each table desired, and only takes effect on new store files. It will be applied to existing store files on the next major compaction (which may be invoked from the hbase shell).
