### PR TITLE
Ensure supervisord starts on reboot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
   - TAGS='site-es-hadoop'
   - TAGS='site-tarsnap'
   - TAGS='site-phantomjs'
+  - TAGS='site-supervisord'
 
 matrix:
   fast_finish: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,6 @@ Vagrant.configure(2) do |config|
         end
         node.vm.hostname = h.split(%r{\s+})[1]
         node.vm.network "private_network", ip: h.split(%r{\s+})[0]
-        node.vm.provision "shell", inline: "service supervisord restart || true", run: "always"
       end
     end
   end

--- a/roles/supervisord/defaults/main.yml
+++ b/roles/supervisord/defaults/main.yml
@@ -3,4 +3,5 @@
 supervisord_log_dir: /var/log/supervisor
 supervisord_programs_dir: /etc/supervisor/conf.d
 supervisord_sock: /var/run/supervisor.sock
+supervisord_inet_http_server: 127.0.0.1:9001
 supervisord_minfds: 64000

--- a/roles/supervisord/tasks/main.yml
+++ b/roles/supervisord/tasks/main.yml
@@ -47,6 +47,12 @@
     state: started
   tags: supervisord
 
+- name: ensure supervisord starts on boot
+  service:
+    name: supervisord
+    enabled: yes
+  tags: supervisord
+
 - name: Set fact supervisord_has_run
   set_fact:
     supervisord_has_run: true

--- a/roles/supervisord/templates/supervisord.conf.j2
+++ b/roles/supervisord/templates/supervisord.conf.j2
@@ -24,4 +24,4 @@ serverurl=unix://{{ supervisord_sock }} ; use a unix:// URL  for a unix socket
 files={{ supervisord_programs_dir }}/*.conf
 
 [inet_http_server]
-port = *:9001
+port={{ supervisord_inet_http_server }}

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -14,6 +14,12 @@
   tags: site-common
   strategy: free
 
+- name: Run supervisord role
+  hosts: all
+  roles:
+    - supervisord
+  tags: site-supervisord
+
 - name: Run virtualenv role
   hosts: all
   roles:


### PR DESCRIPTION
This PR ensures supervisord starts on startup/reboot.

See instructions below: https://github.com/istresearch/ansible-symphony/pull/38#issuecomment-229084524
