### PR TITLE
Using SIGTERM instead of SIGKILL for Kafka

### DIFF
--- a/roles/kafka/templates/kafka-supervisord.conf.j2
+++ b/roles/kafka/templates/kafka-supervisord.conf.j2
@@ -5,4 +5,5 @@ autostart=true
 autorestart=true
 startsecs=5
 user={{ kafka_user }}
-stopsignal=KILL
+stopsignal=TERM
+stopwaitsecs=600


### PR DESCRIPTION
This has been thoroughly tested.
