### PR TITLE
Fixing hadoop handler names

### DIFF
--- a/roles/hadoop/handlers/main.yml
+++ b/roles/hadoop/handlers/main.yml
@@ -35,7 +35,7 @@
     state=started
   when: hdfs_datanode_enabled
 
-- name: restart yarn resourcemanager
+- name: restart yarn resource manager
   supervisorctl:
     name=hadoop-yarn-resourcemanager
     state=restarted
@@ -60,7 +60,7 @@
     state=started
   when: yarn_nodemanager_enabled
 
-- name: restart yarn historyserver
+- name: restart yarn history server
   supervisorctl:
     name=hadoop-yarn-historyserver
     state=restarted
@@ -73,7 +73,7 @@
     state=started
   when: yarn_historyserver_enabled
 
-- name: restart mapreduce historyserver
+- name: restart mapreduce history server
   supervisorctl:
     name=hadoop-mapreduce-historyserver
     state=restarted

--- a/roles/hadoop/tasks/main.yml
+++ b/roles/hadoop/tasks/main.yml
@@ -108,8 +108,12 @@
   notify:
     - restart hdfs namenode
     - wait for hdfs namenode port
+    - restart hdfs secondary namenode
+    - wait for hdfs secondary namenode port
     - restart hdfs datanode
     - wait for hdfs datanode port
+    - restart mapreduce history server
+    - wait for mapreduce history server port
     - restart yarn resource manager
     - wait for yarn resource manager port
     - restart yarn node manager

--- a/roles/hadoop/tasks/mapreduce-historyserver.yml
+++ b/roles/hadoop/tasks/mapreduce-historyserver.yml
@@ -7,11 +7,11 @@
     mode: 0644
   notify:
     - reread supervisord
-    - restart mapreduce historyserver
-    - wait for mapreduce historyserver port
+    - restart mapreduce history server
+    - wait for mapreduce history server port
   tags: hadoop
 
-- name: add historyserver to supervisord
+- name: add history server to supervisord
   supervisorctl:
     name: hadoop-mapreduce-historyserver
     state: present

--- a/roles/hadoop/tasks/yarn-historyserver.yml
+++ b/roles/hadoop/tasks/yarn-historyserver.yml
@@ -7,8 +7,8 @@
     mode: 0644
   notify:
     - reread supervisord
-    - restart yarn historyserver
-    - wait for yarn historyserver port
+    - restart yarn history server
+    - wait for yarn history server port
   tags: hadoop
 
 - name: add historyserver to supervisord

--- a/roles/hadoop/tasks/yarn-nodemanager.yml
+++ b/roles/hadoop/tasks/yarn-nodemanager.yml
@@ -20,7 +20,7 @@
     mode: 0644
   notify:
     - reread supervisord
-    - restart yarn nodemanager
+    - restart yarn node manager
     - wait for yarn node manager port
   tags: hadoop
 

--- a/roles/hadoop/tasks/yarn-resourcemanager.yml
+++ b/roles/hadoop/tasks/yarn-resourcemanager.yml
@@ -48,7 +48,7 @@
     mode: 0644
   notify:
     - reread supervisord
-    - restart yarn resourcemanager
+    - restart yarn resource manager
     - wait for yarn resource manager port
   tags: hadoop
 


### PR DESCRIPTION
How did this work for so long?
