### PR TITLE
Add logrotate role

### DIFF
--- a/roles/logrotate/LICENSE
+++ b/roles/logrotate/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2016-14, Nick Hammond
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of ansiblebit nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/roles/logrotate/defaults/main.yml
+++ b/roles/logrotate/defaults/main.yml
@@ -1,0 +1,11 @@
+logrotate_conf_dir: "/etc/logrotate.d/"
+logrotate_scripts:
+  - name: supervisord
+    path: /var/log/supervisor/*.log
+    options:
+      - size 50M
+      - rotate 5
+      - missingok
+      - compress
+      - delaycompress
+      - copytruncate

--- a/roles/logrotate/tasks/main.yml
+++ b/roles/logrotate/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- block:
+    - name: Install logrotate
+      package:
+        name: logrotate
+        state: present
+
+    - name: Setup logrotate.d scripts
+      template:
+        src: logrotate.d.j2
+        dest: "{{ logrotate_conf_dir }}{{ item.name }}"
+      with_items: "{{ logrotate_scripts }}"
+  when: logrotate_scripts is defined and logrotate_scripts|length > 0

--- a/roles/logrotate/templates/logrotate.d.j2
+++ b/roles/logrotate/templates/logrotate.d.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+
+"{{ item.path }}" {
+  {% if item.options is defined -%}
+  {% for option in item.options -%}
+  {{ option }}
+  {% endfor -%}
+  {% endif %}
+  {%- if item.scripts is defined -%}
+  {%- for name, script in item.scripts.iteritems() -%}
+  {{ name }}
+    {{ script }}
+  endscript
+  {% endfor -%}
+  {% endif -%}
+}

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -35,6 +35,13 @@
     - miniconda
     - deps-traptor
 
+- name: Run logrotate role
+  hosts: all
+  roles:
+    - logrotate
+  tags:
+    - site-logrotate
+
 # -------------------------- Zookeeper and Kafka -----------------------------
 - name: Run zookeeper role
   hosts: zookeeper-nodes


### PR DESCRIPTION
This PR adds the ability to specify files to have under log rotation via logrotate. The role rotates logs under the `/var/log/supervisor` directory by default.
## Testing

(Perform the following **before** running the playbook)

ssh into the vm

```
(vm) $ vagrant ssh vagrant-as-01
```

cd to the supervisord log directory

```
(vm) $ cd /var/log/supervisor
```

create files of various sizes, ensuring they end in `.log`. Make some above 50MB and some below

```
(vm) $ truncate -s 55m test1.log
```

Execute the logrotate task manually

```
(vm) $ /etc/cron.daily/logrotate
```

Observe the files within the supervisord log directory. There should be no change.

```
(vm) $ ls -lh /var/log/supervisor
```

Now run the ansible playbook

```
$ ansible-playbook -u vagrant --limit=vagrant-as-01 --tags="site-logrotate" site-infrastructure.yml
```

Execute the logrotate task manually again within the vm

```
(vm) $ /etc/cron.daily/logrotate
```

Observe the files within the supervisord directory. You should see files ending in `.1` for the example log files created that were larger than 50m

```
(vm) $ ls -lh /var/log/supervisor
```
