### PR TITLE
Add JMX port option to kafka

### DIFF
--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -17,6 +17,7 @@ kafka_data_log_dir:
 kafka_user: kafka
 kafka_group: kafka
 kafka_port: 9092
+kafka_jmx_port: 9999
 kafka_message_max: 10000000
 kafka_replica_fetch_max_bytes: 15000000
 kafka_consumer_message_max: 16777216

--- a/roles/kafka/templates/kafka-supervisord.conf.j2
+++ b/roles/kafka/templates/kafka-supervisord.conf.j2
@@ -1,6 +1,10 @@
 [program:kafka]
 command={{ kafka_install_dir }}/default/bin/kafka-server-start.sh {{ kafka_config_dir }}/server.properties
-environment= KAFKA_HEAP_OPTS="-Xmx{{ kafka_heap }} -Xms{{ kafka_heap }}"
+{% if kafka_jmx_port is defined and kafka_jmx_port %}
+environment=KAFKA_HEAP_OPTS="-Xmx{{ kafka_heap }} -Xms{{ kafka_heap }}", JMX_PORT={{ kafka_jmx_port }}
+{% else %}
+environment=KAFKA_HEAP_OPTS="-Xmx{{ kafka_heap }} -Xms{{ kafka_heap }}"
+{% endif %}
 autostart=true
 autorestart=true
 startsecs=5


### PR DESCRIPTION
Allow JMX port option to be specified for kafka startup.
