### PR TITLE
Oozie fix

### DIFF
--- a/roles/hadoop/defaults/main.yml
+++ b/roles/hadoop/defaults/main.yml
@@ -20,6 +20,11 @@ hdfs_stdout_logfile_maxbytes: 50MB
 hdfs_stderr_logfile_maxbytes: 50MB
 hdfs_env_vars: 'JAVA_HOME="{{ java_home }}", HADOOP_HOME="{{ hdfs_install_dir }}/default", YARN_HOME="{{ hdfs_install_dir }}/default", HADOOP_PREFIX="/opt/hadoop/default"'
 
+hadoop_proxyusers:
+  - user: 'mapred'
+    hosts: '*'
+    groups: '*'
+
 hdfs_datanode_enabled: false
 hdfs_namenode_enabled: false
 hdfs_secondary_namenode_enabled: false

--- a/roles/hadoop/templates/core-site.xml.j2
+++ b/roles/hadoop/templates/core-site.xml.j2
@@ -24,14 +24,19 @@
     <value>hdfs://{{ dfs_namenode_host }}:{{ dfs_namenode_port|default(8020) }}</value>
   </property>
 
+{% for proxyuser in hadoop_proxyusers %}
+{% if proxyuser.groups is defined %}
   <property>
-    <name>hadoop.proxyuser.mapred.groups</name>
-    <value>*</value>
+      <name>hadoop.proxyuser.{{ proxyuser.user }}.groups</name>
+      <value>{{ proxyuser.groups }}</value>
   </property>
-
+{% endif %}
+{% if proxyuser.hosts is defined %}
   <property>
-    <name>hadoop.proxyuser.mapred.hosts</name>
-    <value>*</value>
+      <name>hadoop.proxyuser.{{ proxyuser.user }}.hosts</name>
+      <value>{{ proxyuser.hosts }}</value>
   </property>
+{% endif %}
+{% endfor %}
 
 </configuration>

--- a/roles/oozie/tasks/main.yml
+++ b/roles/oozie/tasks/main.yml
@@ -110,7 +110,7 @@
         -Dpackaging=jar
 
     - name: make oozie distro (long running)
-      command: bin/mkdistro.sh -DskipTests -Puber
+      command: bin/mkdistro.sh -DskipTests -Puber -Phadoop-2
       args:
         chdir: "{{ oozie_install_dir }}/default"
 

--- a/roles/oozie/templates/pom.xml.j2
+++ b/roles/oozie/templates/pom.xml.j2
@@ -1780,8 +1780,8 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <hadoop.version>2.4.0</hadoop.version>
-                <hadoop.majorversion>2</hadoop.majorversion>
+                <hadoop.version>{{ oozie_external_vars.hdfs_version }}</hadoop.version>
+                <hadoop.majorversion>{{ oozie_external_vars.hdfs_version.split('.')[0] }}</hadoop.majorversion>
                 <pig.classifier>h2</pig.classifier>
                 <sqoop.classifier>hadoop200</sqoop.classifier>
                 <jackson.version>1.9.13</jackson.version>


### PR DESCRIPTION
Fix oozie build process. Additionally, allow proxyusers in hadoop to be specified via the`hadoop_proxyusers` variable.
