### PR TITLE
hdfs checkpoint fix

### DIFF
--- a/roles/hadoop/defaults/main.yml
+++ b/roles/hadoop/defaults/main.yml
@@ -48,7 +48,9 @@ dfs_namenode_secondary_http_address_port: 50090
 dfs_namenode_secondary_https_address_port: 50091
 
 dfs_namenode_name_dir: /data/dfs/nn
-dfs_datanode_data_dir: /data/dfs/dn
+dfs_datanode_data_dir: 
+   - '/data/dfs/dn'
+dfs_tmp_dir: /data/dfs/tmp/hdfs-checkpoints
 dfs_replication: 3
 dfs_block_size: 134217728
 dfs_datanode_max_transfer_threads: 8192
@@ -68,8 +70,10 @@ yarn_nodemanager_address_port: 8041
 yarn_nodemanager_localizer_address: 8040
 yarn_nodemanager_webapp_address_port: 8042
 
-yarn_nodemanager_local_dirs: /data/yarn/local
-yarn_nodemanager_log_dirs: /data/yarn/logs
+yarn_nodemanager_local_dirs: 
+   - /data/yarn/local
+yarn_nodemanager_log_dirs: 
+   - /data/yarn/logs
 yarn_nodemanager_remote_app_log_dir: /var/log/hadoop-yarn/apps
 
 yarn_resourcemanager_address_port: 8032

--- a/roles/hadoop/tasks/hdfs-namenode.yml
+++ b/roles/hadoop/tasks/hdfs-namenode.yml
@@ -8,6 +8,7 @@
     group={{ hdfs_group }}
   with_items:
     - "{{ dfs_namenode_name_dir }}"
+    - "{{ dfs_tmp_dir }}"
   tags:
     - hadoop
     - hdfs_namenode

--- a/roles/hadoop/tasks/hdfs-secondary-namenode.yml
+++ b/roles/hadoop/tasks/hdfs-secondary-namenode.yml
@@ -1,12 +1,45 @@
 ---
 
+- name: create data directories
+  file:
+    path={{ item }}
+    state=directory
+    mode=0755
+    owner={{ hdfs_user }}
+    group={{ hdfs_group }}
+  with_items:
+    - "{{ dfs_namenode_name_dir }}"
+    - "{{ dfs_tmp_dir }}"
+  tags:
+    - hadoop
+    - hdfs_secondary_namenode
+
 - name: copy supervisord config
   template:
     src: hadoop-secondary-namenode-supervisord.conf.j2
-    dest: "{{ supervisord_programs_dir }}/hadoop-namenode-supervisord.conf"
+    dest: "{{ supervisord_programs_dir }}/hadoop-secondary-namenode-supervisord.conf"
     mode: 0644
   notify:
     - reread supervisord
     - restart hdfs secondary namenode
     - wait for hdfs secondary namenode port
+  tags: hadoop
+
+- name: add namenode to supervisord
+  supervisorctl:
+    name: hadoop-hdfs-secondary-namenode
+    state: present
+  tags: hadoop
+
+- name: ensure namenode is started
+  supervisorctl:
+    name: hadoop-hdfs-secondary-namenode
+    state: started
+  notify:
+    - wait for hdfs secondary namenode port
+  tags: hadoop
+
+- name: wait for hdfs secondary namenode port
+  wait_for:
+    port: "{{ dfs_namenode_secondary_http_address_port }}"
   tags: hadoop

--- a/roles/hadoop/templates/core-site.xml.j2
+++ b/roles/hadoop/templates/core-site.xml.j2
@@ -34,4 +34,9 @@
     <value>*</value>
   </property>
 
+  <property>
+    <name>hadoop.tmp.dir</name>
+    <value>file://{{ dfs_tmp_dir }}</value>
+  </property>
+
 </configuration>

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -208,7 +208,7 @@
   vars:
     - hdfs_namenode_enabled: true
     - yarn_resourcemanager_enabled: true
-    - yarn_historyserver_enabled: true
+    - yarn_historyserver_enabled: false
     - mapreduce_historyserver_enabled: true
     - dfs_namenode_host: "{{ groups['hadoop-namenode-node'][0] }}"
     - yarn_resourcemanager_hostname: "{{ groups['hadoop-namenode-node'][0] }}"


### PR DESCRIPTION
(cherry picked from the private repo)
This is to fix the secondary namenode checkpoints

To test this:
1) Bring up your 2 vagrant vm's
`vagrant up vagrant-as-01 vagrant-as-02`

2) Run this playbook and make sure no errors occur. If errors do occur, take note and leave a comment here.
`ansible-playbook -i staging.inventory -u vagrant -t deps-hadoop site-infrastructure.yml`

3) Create a tunnel with the secondary namenode and confirm the checkpoint settings.
`ssh -L 50090:vagrant-as-02:50090 vagrant@vagrant-as-02`
Open browser and go to localhost:50090
Make sure the **Checkpoint Image URI** and **Checkpoint Edit Log URI** have `file:///data/dfs/tmp/hdfs-checkpoints/dfs/namesecondary` as their values.

If it has a different value, then report it here.
