### PR TITLE
Elasticsearch slow log now correctly writes to log files

### DIFF
--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -100,4 +100,7 @@ elasticsearch_logger_indexing: "{{ elasticsearch_log_trace }}"
 elasticsearch_additivity_search: "false"
 elasticsearch_additivity_indexing: "false"
 
+elasticsearch_logging_slowlog_mode: "standard" # standard, showall, off
+elasticsearch_logger_type: "dailyRollingFile" # dailyRollingFile, file
+
 repository_infrastructure: "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/{{ elasticsearch_version }}"

--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -88,7 +88,48 @@ path.logs: {{ elasticsearch_log_dir }}_{{ conf_name }}
 #
 # path.plugins: /path/to/plugins
 path.plugins: {{ elasticsearch_plugin_dir }}
+
 #
+# ----------------------------------- Slow Logs --------------------------------
+#
+{% if elasticsearch_logging_slowlog_mode != "off" %}
+index.indexing.slowlog.level: info
+index.indexing.slowlog.source: 1000
+
+{% if elasticsearch_logging_slowlog_mode == "standard" %}
+index.search.slowlog.threshold.query.warn: 10s
+index.search.slowlog.threshold.query.info: 5s
+index.search.slowlog.threshold.query.debug: 2s
+index.search.slowlog.threshold.query.trace: 500ms
+
+index.search.slowlog.threshold.fetch.warn: 1s
+index.search.slowlog.threshold.fetch.info: 800ms
+index.search.slowlog.threshold.fetch.debug: 500ms
+index.search.slowlog.threshold.fetch.trace: 200ms
+
+index.indexing.slowlog.threshold.index.warn: 10s
+index.indexing.slowlog.threshold.index.info: 5s
+index.indexing.slowlog.threshold.index.debug: 2s
+index.indexing.slowlog.threshold.index.trace: 500ms
+{% elif elasticsearch_logging_slowlog_mode == "showall" %}
+index.search.slowlog.threshold.query.warn: 0s
+index.search.slowlog.threshold.query.info: 0s
+index.search.slowlog.threshold.query.debug: 0s
+index.search.slowlog.threshold.query.trace: 0s
+
+index.search.slowlog.threshold.fetch.warn: 0s
+index.search.slowlog.threshold.fetch.info: 0s
+index.search.slowlog.threshold.fetch.debug: 0s
+index.search.slowlog.threshold.fetch.trace: 0s
+
+index.indexing.slowlog.threshold.index.warn: 0s
+index.indexing.slowlog.threshold.index.info: 0s
+index.indexing.slowlog.threshold.index.debug: 0s
+index.indexing.slowlog.threshold.index.trace: 0s
+{% endif %}
+{% endif %}
+
+
 # ----------------------------------- Memory -----------------------------------
 #
 # Lock the memory on startup:

--- a/roles/elasticsearch/templates/logging.yml.j2
+++ b/roles/elasticsearch/templates/logging.yml.j2
@@ -32,7 +32,7 @@ appender:
       conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
 
   file:
-    type: dailyRollingFile
+    type: {{ elasticsearch_logger_type }}
     file: ${path.logs}/${cluster.name}.log
     datePattern: "'.'yyyy-MM-dd"
     layout:
@@ -40,7 +40,7 @@ appender:
       conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
 
   index_search_slow_log_file:
-    type: dailyRollingFile
+    type: {{ elasticsearch_logger_type }}
     file: ${path.logs}/${cluster.name}_index_search_slowlog.log
     datePattern: "'.'yyyy-MM-dd"
     layout:
@@ -48,7 +48,7 @@ appender:
       conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
 
   index_indexing_slow_log_file:
-    type: dailyRollingFile
+    type: {{ elasticsearch_logger_type }}
     file: ${path.logs}/${cluster.name}_index_indexing_slowlog.log
     datePattern: "'.'yyyy-MM-dd"
     layout:


### PR DESCRIPTION
This PR correctly enables the slowlog for Elasticsearch. Additionally, different logging level configurations are provided so we can easily use conventional slow logging, no slog logging at all, or we can log everything possible.
## Testing

Run the ES role

```
$ ansible-playbook -i staging.inventory -u vagrant --tags="site-elasticsearch" --limit=vagrant-as-01 site-infrastructure.yml
```

SSH into the vm

```
$ vagrant ssh vagrant-as-01
```

Become root

```
(vagrant-as-01)$ sudo su
```

Install the following for testing purposes

```
(vagrant-as-01)# apt-get install php5-cli php5-curl
```

Download the following php script that will populate a test index

```
(vagrant-as-01)# wget https://github.com/royrusso/elasticsearch-sample-index/archive/master.zip && unzip master.zip
(vagrant-as-01)# cd elasticsearch-sample-index-master
```

Restart Elasticsearch under supervisor

```
(vagrant-as-01)# supervisorctl
supervisor> restart elasticsearch-master_data
elasticsearch-master_data: stopped
elasticsearch-master_data: started
```

Create the test index

```
curl -XPUT 'http://vagrant-as-01:9200/comicbook/' -d '{
    "settings" : {
        "index" : {
            "number_of_shards" : 3,
            "number_of_replicas" : 1
        }
    }
}'
```

Open the _elasticput.php_ file in vi and change the line

``` php
$esHost = 'localhost';
```

to

``` php
$esHost = 'vagrant-as-01';
```

Run the php script

```
(vagrant-as-01)# php elasticput.php
```

Execute the following ES search

```
(vagrant-as-01)# curl "http://vagrant-as-01:9200/comicbook/superhero/_search?q=summary:Kent"
```

cd to the Elasticsearch log directory

```
(vagrant-as-01)# cd /var/log/elasticsearch_master_data
```

Observe that the indexing and search slow logs are both populated
