### PR TITLE
Adding dfs.replication setting to HBase

### DIFF
--- a/roles/hbase/defaults/main.yml
+++ b/roles/hbase/defaults/main.yml
@@ -19,6 +19,7 @@ hbase_stderr_logfile_maxbytes: 50MB
 # runtime opts
 hbase_heap_size: 1024
 hbase_opts: -XX:+UseConcMarkSweepGC
+hbase_dfs_replication: 3
 
 hbase_master_enabled: false
 hbase_regionserver_enabled: false

--- a/roles/hbase/templates/hbase-site.xml.j2
+++ b/roles/hbase/templates/hbase-site.xml.j2
@@ -109,4 +109,10 @@
   </property>
   
 {% endif %}
+
+  <property>
+    <name>dfs.replication</name>
+    <value>{{ hbase_dfs_replication|default(3) }}</value>
+  </property>
+
 </configuration>


### PR DESCRIPTION
To configure the HDFS replication on new data written, it requires the `dfs.replication` setting HBase will use in it's HDFS client.

This config change will require region servers to be restarted.
