### PR TITLE
Add Exim4 role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
   - TAGS='site-phantomjs'
   - TAGS='site-supervisord'
   - TAGS='site-oozie'
+  - TAGS='site-exim'
 
 matrix:
   fast_finish: true

--- a/roles/exim/defaults/main.yml
+++ b/roles/exim/defaults/main.yml
@@ -7,7 +7,7 @@ exim_confd: "{{ exim_conf_dir }}/conf.d"
 exim_amazon_ses_conf:
   conf_name: 'amazon_ses'
   region_endpoint: 'email-smtp.us-east-1.amazonaws.com'
-  port: 25
+  port: 587
   username: 'smtp_username'
   password: 'smtp_password'
 

--- a/roles/exim/defaults/main.yml
+++ b/roles/exim/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+
+exim_mailname: yourdomain.com
+exim_conf_dir: /etc/exim4
+exim_confd: "{{ exim_conf_dir }}/conf.d"
+
+exim_amazon_ses_conf:
+  conf_name: 'amazon_ses'
+  region_endpoint: 'email-smtp.us-east-1.amazonaws.com'
+  port: 25
+  username: 'smtp_username'
+  password: 'smtp_password'
+
+exim_configs: []
+# - "{{ exim_amazon_ses_conf.conf_name }}"

--- a/roles/exim/tasks/main.yml
+++ b/roles/exim/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+
+- name: Install exim
+  apt:
+    pkg: exim4
+    state: present
+  tags: exim-install
+
+- block:
+  - name: Populate /etc/mailname
+    template:
+      src: mailname.j2
+      dest: /etc/mailname
+      group: root
+      owner: root
+
+  - name: Use split configuration mode
+    lineinfile:
+      dest: "{{ exim_conf_dir }}/update-exim4.conf.conf"
+      line: dc_use_split_config='true'
+      regexp: dc_use_split_config=
+
+  # The auth config example causes conflicts with custom authentication
+  - name: Remove auth config example
+    file:
+      path: "{{ exim_confd }}/auth/30_exim4-config_examples"
+      state: absent
+
+  - name: Remove ansiblized configs
+    command: find {{ exim_confd }} -type f -name "*ansible*" -exec rm {} \;
+
+    ################################################################################
+    # Use '%02d'|format(item.0|int + 1) to start looping index from 1 to avoid
+    # conflicts with existing 00 configs. Also format to pad with leading 0 if < 10.
+    ################################################################################
+  - name: Populate exim confd routers
+    template:
+      src: "{{ item }}/router.j2"
+      dest: "{{ exim_confd }}/router/{{ '%02d'|format(item.0|int + 1) }}_ansible-{{ item }}"
+    with_items: "{{ exim_configs }}"
+
+  - name: Populate exim confd auth
+    template:
+      src: "{{ item }}/auth.j2"
+      dest: "{{ exim_confd }}/auth/{{ '%02d'|format(item.0|int + 1) }}_ansible-{{ item }}"
+    with_items: "{{ exim_configs }}"
+
+  - name: Populate exim confd transport
+    template:
+      src: "{{ item }}/transport.j2"
+      dest: "{{ exim_confd }}/transport/{{ '%02d'|format(item.0|int + 1) }}_ansible-{{ item }}"
+    with_items: "{{ exim_configs }}"
+  tags: exim-configure
+
+- block:
+  - name: Generate master exim config
+    command: update-exim4.conf
+
+  - name: Load generated exim config
+    service:
+      name: exim4
+      state: reloaded
+  tags:
+    - exim-reload
+    - exim-configure

--- a/roles/exim/templates/amazon_ses/auth.j2
+++ b/roles/exim/templates/amazon_ses/auth.j2
@@ -1,0 +1,4 @@
+ses_login:
+driver = plaintext
+public_name = LOGIN
+client_send = : {{ exim_amazon_ses_conf.username }} : {{ exim_amazon_ses_conf.password }}

--- a/roles/exim/templates/amazon_ses/router.j2
+++ b/roles/exim/templates/amazon_ses/router.j2
@@ -1,0 +1,5 @@
+send_via_ses:
+driver = manualroute
+domains = ! +local_domains
+transport = ses_smtp
+route_list = * {{ exim_amazon_ses_conf.region_endpoint }};

--- a/roles/exim/templates/amazon_ses/transport.j2
+++ b/roles/exim/templates/amazon_ses/transport.j2
@@ -1,0 +1,5 @@
+ses_smtp:
+driver = smtp
+port = {{ exim_amazon_ses_conf.port }}
+hosts_require_auth = $host_address
+hosts_require_tls = $host_address

--- a/roles/exim/templates/mailname.j2
+++ b/roles/exim/templates/mailname.j2
@@ -1,0 +1,1 @@
+{{ exim_mailname }}

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -42,6 +42,13 @@
   tags:
     - site-logrotate
 
+- name: Run exim role
+  hosts: all
+  roles:
+    - exim
+  tags:
+    - site-exim
+
 # -------------------------- Zookeeper and Kafka -----------------------------
 - name: Run zookeeper role
   hosts: zookeeper-nodes


### PR DESCRIPTION
This PR adds the Exim4 Mail Transfer Agent. Currently the only exim configuration available is `amazon_ses`.

## Testing

Make the following adjustments to the `roles/exim/defaults/main.yml` file:

1. Change `exim_mailname` to the proper domain (`istresearch.com` for IST employees)
2. Alter the `username` and `password` for the `exim_amazon_ses_conf`. (IST employees can find SES credentials in LastPass)
3. Change
        
        exim_configs: []
        # - "{{ exim_amazon_ses_conf.conf_name }}"

to

    exim_configs:
      - "{{ exim_amazon_ses_conf.conf_name }}"

Run the exim role:

    $ ansible-playbook -v -i staging.inventory -u vagrant --limit=vagrant-as-01 --tags="site-exim" site-infrastructure.yml

SSH into `vagrant-as-01` and send yourself an email using the following command:

    (vagrant-as-01)$ echo "This is a test." | mail -v -s TheSubject your_email@gmail.com

The command should have the following as the last lines in the output:

```
LOG: MAIN
  Completed
```

You should also have received the email in your inbox.