### PR TITLE
Watermarks update

### DIFF
--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -38,6 +38,11 @@ elasticsearch_misc_query_bool_max_clause_count: 4096
 elasticsearch_memory_bootstrap_mlockall: "true"
 elasticsearch_base_node_name: esnode
 
+elasticsearch_disk_threshold_enabled: True
+elasticsearch_watermark_low: 85%
+elasticsearch_watermark_high: 90%
+elasticsearch_update_interval: 30s
+
 elasticsearch_gateway_type: local
 elasticsearch_gateway_recover_after_nodes: 1
 elasticsearch_gateway_recover_after_time: 2m

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -29,6 +29,11 @@
     name: vm.max_map_count
     value: 262144   
 
+- name: Get Base Node Name from Hostname
+  shell: hostname | awk -F . '{print $1}'
+  register: elasticsearch_base_node_name
+  tags: elasticsearch
+
 - name: Configuring group
   group:
     name: "{{ elasticsearch_group }}"

--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -23,9 +23,7 @@ cluster.name: {{ elasticsearch_cluster_name }}
 #
 # node.name: node-1
 
-{% for host in elasticsearch_host_list %}
-{%- if host == inventory_hostname -%}node.name: {{ elasticsearch_base_node_name }}-{{ loop.index }}-{{ conf_name }}{%- endif -%}
-{% endfor %}
+node.name: {{ elasticsearch_base_node_name.stdout }}-{{ conf_name }}
 
 #
 # Add custom attributes to the node:
@@ -144,6 +142,11 @@ index.indexing.slowlog.threshold.index.trace: 0s
 {% endif %}
 {% endif %}
 
+# ----------------------------------- Watermarks -----------------------------------
+cluster.routing.allocation.disk.threshold_enabled: {{ elasticsearch_disk_threshold_enabled }}
+cluster.routing.allocation.disk.watermark.low: {{ elasticsearch_watermark_low }}
+cluster.routing.allocation.disk.watermark.high: {{ elasticsearch_watermark_high }}
+cluster.info.update.interval: {{ elasticsearch_update_interval }}
 
 # ----------------------------------- Memory -----------------------------------
 #

--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -13,10 +13,10 @@ mysql_enablerepo: ""
 # Define a custom list of packages to install; if none provided, the default
 # package list from vars/[OS-family].yml will be used.
 #mysql_packages:
-  #- mysql-client-core-5.5
-  #- mysql-server-5.5
-  #- mysql-server
-  #- MySQL-python
+ # - mysql-client-core-5.5
+ # - mysql-server-5.5
+ # - mysql-server
+ # - MySQL-python
 
 # MySQL connection settings.
 mysql_port: "3306"

--- a/roles/mysql/vars/Debian.yml
+++ b/roles/mysql/vars/Debian.yml
@@ -1,8 +1,8 @@
 ---
-__mysql_daemon: mysql
-__mysql_packages:
+mysql_daemon: mysql
+mysql_packages:
   - mysql-common
   - mysql-server
-__mysql_slow_query_log_file: /var/log/mysql/mysql-slow.log
+mysql_slow_query_log_file: /var/log/mysql/mysql-slow.log
 mysql_config_file: /etc/mysql/my.cnf
 mysql_socket: /var/run/mysqld/mysqld.sock

--- a/roles/mysql/vars/Debian.yml
+++ b/roles/mysql/vars/Debian.yml
@@ -5,6 +5,7 @@ mysql_packages:
   - mysql-client-core-5.5
   - mysql-server-5.5
   - mysql-server
+  - mysql-server-core-5.5
 #  - mysql-python
 mysql_slow_query_log_file: /var/log/mysql/mysql-slow.log
 mysql_config_file: /etc/mysql/my.cnf

--- a/roles/mysql/vars/Debian.yml
+++ b/roles/mysql/vars/Debian.yml
@@ -2,7 +2,10 @@
 mysql_daemon: mysql
 mysql_packages:
   - mysql-common
+  - mysql-client-core-5.5
+  - mysql-server-5.5
   - mysql-server
+#  - mysql-python
 mysql_slow_query_log_file: /var/log/mysql/mysql-slow.log
 mysql_config_file: /etc/mysql/my.cnf
 mysql_socket: /var/run/mysqld/mysqld.sock


### PR DESCRIPTION
This PR tests the addition of watermark settings to the elasticsearch.yml file as well as making the node name of the elasticsearch node be based on the short hostname (as opposed to the FQDN) of the server/node.

1) Run `vagrant up` to bring up the vagrant-as-01 and vagrant-as-02 vm's.
2) Next run this ansible-playbook command
`ansible-playbook -i staging.inventory -u vagrant -t site-elasticsearch site-infrastructure.yml`
3) After ansible completes, log in to the VM
`vagrant ssh vagrant-as-01`
4) check that the elasticsearch.yml file has the configurations for the node.name and watermarks set:
`sudo cat /opt/elasticsearch/default/config_master_data/elasticsearch.yml | grep "node\.name"`
should produce:
`# node.name: node-1
node.name: vagrant-as-01-master_data`
and
`sudo cat  #/opt/elasticsearch/default/config_master_data/elasticsearch.yml | grep -A 4 "Watermarks"`
should produce:
`# ----------------------------------- Watermarks -----------------------------------
cluster.routing.allocation.disk.threshold_enabled: True
cluster.routing.allocation.disk.watermark.low: 85%
cluster.routing.allocation.disk.watermark.high: 90%
cluster.info.update.interval: 30s`

Please write in the comments below if any of these fail or produce results that aren't expected.