### PR TITLE
Add optional nginx proxy to Elasticsearch role

### DIFF
--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -115,3 +115,18 @@ elasticsearch_logging_slowlog_mode: "standard" # standard, showall, off
 elasticsearch_logger_type: "dailyRollingFile" # dailyRollingFile, file
 
 repository_infrastructure: "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/{{ elasticsearch_version }}"
+
+###########################################
+# Nginx proxy
+###########################################
+elasticsearch_nginx_proxy_enabled: false
+elasticsearch_nginx_proxy:
+  nginx_worker_user: 'www-data'
+  shell: '/bin/false'
+  listen_port: 9201
+  upstream_port: "{{ elasticsearch_network_http_port|default(9200) }}"
+  nginx_conf_path: '/etc/nginx/nginx.conf'
+elasticsearch_nginx_proxy_auth:
+  user: 'user'
+  password: 'password'
+  htpasswd_file: '/etc/nginx/.htpasswd'

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -236,3 +236,9 @@
   notify: "restart elasticsearch {{ conf_name }}"
   tags:
     - elasticsearch
+
+- name: include nginx_proxy tasks
+  include: nginx_proxy.yml
+  when: elasticsearch_nginx_proxy_enabled is defined and elasticsearch_nginx_proxy_enabled
+  tags:
+    - elasticsearch

--- a/roles/elasticsearch/tasks/nginx_proxy.yml
+++ b/roles/elasticsearch/tasks/nginx_proxy.yml
@@ -1,0 +1,36 @@
+---
+#########################################################################
+# Configure an nginx proxy in front of Elasticsearch
+#########################################################################
+- name: Install nginx
+  apt:
+    name=nginx
+    state=latest
+
+- name: Make sure we can use htpasswd module
+  apt:
+    name=python-passlib
+    state=installed
+
+- name: Create user nginx worker will run as
+  user:
+    name: "{{ elasticsearch_nginx_proxy.nginx_worker_user }}"
+    shell: "{{ elasticsearch_nginx_proxy.shell }}"
+    createhome: no
+    system: yes
+
+- name: Populate nginx conf
+  template:
+    src=nginx-proxy.conf.j2
+    dest={{ elasticsearch_nginx_proxy.nginx_conf_path }}
+
+- name: Add basic auth credentials to htpasswd file
+  htpasswd:
+    path: "{{ elasticsearch_nginx_proxy_auth.htpasswd_file }}"
+    name: "{{ elasticsearch_nginx_proxy_auth.user }}"
+    password: "{{ elasticsearch_nginx_proxy_auth.password }}"
+
+- name: Reload nginx
+  service:
+    name=nginx
+    state=reloaded

--- a/roles/elasticsearch/templates/nginx-proxy.conf.j2
+++ b/roles/elasticsearch/templates/nginx-proxy.conf.j2
@@ -1,0 +1,42 @@
+############################## IMPORTANT ######################################
+# Always run the following command to test the config before restarting
+# $ nginx -t
+################################ DO IT! #######################################
+
+user {{ elasticsearch_nginx_proxy.nginx_worker_user }};
+
+events {
+    worker_connections  2048;
+}
+
+http {
+  log_format   main '$host $remote_addr - $remote_user [$time_local]  $status ' '"$request" $body_bytes_sent "$http_referer" ' '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log /var/log/nginx/access.log main;
+  error_log  /var/log/nginx/error.log;
+  client_max_body_size 100M;
+
+  upstream local_es {
+    server {{ inventory_hostname }}:{{ elasticsearch_nginx_proxy.upstream_port }};
+    keepalive 15;
+  }
+
+  server {
+    listen {{ elasticsearch_nginx_proxy.listen_port }};
+
+    auth_basic "Protected Elasticsearch";
+    auth_basic_user_file {{ elasticsearch_nginx_proxy_auth.htpasswd_file }};
+
+    location / {
+      proxy_pass http://local_es;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "Keep-Alive";
+      proxy_set_header Proxy-Connection "Keep-Alive";
+      proxy_connect_timeout       300;
+      proxy_send_timeout          300;
+      proxy_read_timeout          300;
+      send_timeout                300;
+    }
+
+  }
+  include /etc/nginx/sites-enabled/*;
+}


### PR DESCRIPTION
This PR allows us to configure nginx to serve as a proxy in front of Elasticsearch. The assumption here is that nginx is not used for anything else on the server, as it overwrites the nginx.conf file.

## Testing

Set `elasticsearch_nginx_proxy_enabled` to `true`.

Run the elasticsearch role:

```shell
$ ansible-playbook -i staging.inventory -u vagrant --tags="site-elasticsearch" --limit=vagrant-as-01 site-infrastructure.yml
```

SSH into the vm

```shell
$ vagrant ssh vagrant-as-01
```

Verify you can hit the local ES instance directly on port 9200

```
vagrant@vagrant-as-01:~$ curl "http://vagrant-as-01:9200"
{
  "name" : "vagrant-as-01-master_data",
  "cluster_name" : "elasticsearch",
  "version" : {
    "number" : "2.3.1",
    "build_hash" : "bd980929010aef404e7cb0843e61d0665269fc39",
    "build_timestamp" : "2016-04-04T12:25:05Z",
    "build_snapshot" : false,
    "lucene_version" : "5.5.0"
  },
  "tagline" : "You Know, for Search"
}
```

Verify when you try to hit the nginx proxy running on 9201 without credentials you get rejected

```
vagrant@vagrant-as-01:~$ curl "http://vagrant-as-01:9201"
<html>
<head><title>401 Authorization Required</title></head>
<body bgcolor="white">
<center><h1>401 Authorization Required</h1></center>
<hr><center>nginx/1.4.6 (Ubuntu)</center>
</body>
</html>
```

Verify the request through the proxy succeeds when the proper credentials are provided

```
vagrant@vagrant-as-01:~$ curl "http://user:password@vagrant-as-01:9201"
{
  "name" : "vagrant-as-01-master_data",
  "cluster_name" : "elasticsearch",
  "version" : {
    "number" : "2.3.1",
    "build_hash" : "bd980929010aef404e7cb0843e61d0665269fc39",
    "build_timestamp" : "2016-04-04T12:25:05Z",
    "build_snapshot" : false,
    "lucene_version" : "5.5.0"
  },
  "tagline" : "You Know, for Search"
}
```

Verify the nginx error and access logs are being written to

```
$ sudo tail /var/log/nginx/access.log
...
$ sudo tail /var/log/nginx/error.log
...
```