### PR TITLE
Specify Timezone in Common Role

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -4,6 +4,12 @@ ntp_server_host: pool.ntp.org
 common_data_dir: /data
 common_data_user: root
 common_data_group: root
+#################################################################
+# For list of timezones, see
+# https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+#################################################################
+common_timezone: 'UTC'
+
 swap_run: true
 swap_file: /var/swap
 swap_size: 2000000000

--- a/roles/common/tasks/setup-Debian.yml
+++ b/roles/common/tasks/setup-Debian.yml
@@ -70,3 +70,20 @@
     dest: /etc/apt/apt.conf.d/50unattended-upgrades
     group: root
     owner: root
+
+- name: Set Time Zone
+  hosts: Ubuntu
+  gather_facts: False
+  tasks:
+    - name: Set timezone variables
+      copy: content='America/Los_Angeles'
+            dest=/etc/timezone
+            owner=root
+            group=root
+            mode=0644
+            backup=yes
+      notify:
+        - update timezone
+  handlers:
+    - name: update timezone
+      command: dpkg-reconfigure --frontend noninteractive tzdata

--- a/roles/common/tasks/setup-Debian.yml
+++ b/roles/common/tasks/setup-Debian.yml
@@ -70,20 +70,20 @@
     dest: /etc/apt/apt.conf.d/50unattended-upgrades
     group: root
     owner: root
+  tags:
+    - common
 
 - name: Set Time Zone
-  hosts: Ubuntu
-  gather_facts: False
-  tasks:
-    - name: Set timezone variables
-      copy: content='America/Los_Angeles'
-            dest=/etc/timezone
-            owner=root
-            group=root
-            mode=0644
-            backup=yes
-      notify:
-        - update timezone
-  handlers:
-    - name: update timezone
-      command: dpkg-reconfigure --frontend noninteractive tzdata
+  copy: content={{ common_timezone }}
+        dest=/etc/timezone
+        owner=root
+        group=root
+        mode=0644
+        backup=yes
+  tags:
+    - common
+
+- name: Update timezone via dpkg
+  command: dpkg-reconfigure --frontend noninteractive tzdata
+  tags:
+    - common


### PR DESCRIPTION
This PR enables us to specify the server timezone via the common role. The default timezone is UTC.

Tests
-----

Checkout this branch

    $ git fetch && git checkout --track origin/timezone

Run the common role

    $ ansible-playbook -u vagrant -i staging.inventory --tags="site-common" site-infrastructure.yml

SSH into the vagrant-as-01 vm and run the `date` command. You should see UTC time.

Now alter the `common_timezone` variable in `roles/common/defaults/main.yml` as follows:

```
+#################################################################
+# For list of timezones, see
+# https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+#################################################################
+common_timezone: 'America/Chicago'
```

Rerun the common role

    $ ansible-playbook -u vagrant -i staging.inventory --tags="site-common" site-infrastructure.yml

SSH into the vm and run the `date` command. You should see `CST` time
