### PR TITLE
Add ctop to docker-engine role

### DIFF
--- a/roles/docker-engine/defaults/main.yml
+++ b/roles/docker-engine/defaults/main.yml
@@ -31,3 +31,5 @@ docker_kernel_pkg_state: latest
 docker_pidproxy_install_dir: /opt/pidproxy
 docker_pid_file: "{{ docker_pidproxy_install_dir }}/docker.pid"
 docker_stop_signal: INT
+
+docker_install_ctop: true

--- a/roles/docker-engine/tasks/main.yml
+++ b/roles/docker-engine/tasks/main.yml
@@ -61,7 +61,7 @@
   get_url:
     url: https://raw.githubusercontent.com/yadutaf/ctop/master/cgroup_top.py
     dest: /usr/local/bin/ctop
-    mode: 755
+    mode: 0755
   when: docker_install_ctop is defined and docker_install_ctop
 
 

--- a/roles/docker-engine/tasks/main.yml
+++ b/roles/docker-engine/tasks/main.yml
@@ -54,6 +54,17 @@
     - { name: docker-py, version: "{{ docker_py_version }}" }
     - { name: docker-compose, version: "{{ docker_compose_version }}" }
 
+################################################################################
+# top command, for containers: https://github.com/yadutaf/ctop
+################################################################################
+- name: Install ctop
+  get_url:
+    url: https://raw.githubusercontent.com/yadutaf/ctop/master/cgroup_top.py
+    dest: /usr/local/bin/ctop
+    mode: 755
+  when: docker_install_ctop is defined and docker_install_ctop
+
+
 #- name: stop docker service
 #  service:
 #    name: docker


### PR DESCRIPTION
This PR adds the `ctop` command (found here: https://github.com/yadutaf/ctop) to the docker-engine role.

Testing
-------

Check out the branch

    $ git checkout --track origin/ctop

Run the docker-engine role. If this is your first time running the role, it may take ~15 minutes to install the latest kernel.

    $ ansible-playbook -u vagrant -i staging.inventory --tags="site-docker-engine" site-infrastructure.yml

SSH into vagrant-as-01 and attempt to run

    $ ctop

The `ctop` interface should appear. Press the `q` key on your keyboard to exit.