### PR TITLE
Python role fix

### DIFF
--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -6,48 +6,44 @@
     - python
 
 - block:
-    - name: update apt-get cache
-      apt: update-cache=yes
-      tags: 
-        - python
+  - name: update apt-get cache
+    apt: update-cache=yes
 
-    - name: install packages needed to compile python
-      apt:
-        name={{ item }}
-        state=latest
-      with_items:
-        - autotools-dev
-        - blt-dev
-        - bzip2
-        - dpkg-dev
-        - g++-multilib
-        - gcc-multilib
-        - libbluetooth-dev
-        - libbz2-dev
-        - libexpat1-dev
-        - libffi-dev
-        - libffi6
-        - libffi6-dbg
-        - libgdbm-dev
-        - libgpm2
-        - libncursesw5-dev
-        - libreadline-dev
-        - libsqlite3-dev
-        - libssl-dev
-        - libtinfo-dev
-        - mime-support
-        - net-tools
-        - netbase
-        - python-crypto
-        - python-mox3
-        - python-pil
-        - python-ply
-        - quilt
-        - tk-dev
-        - zlib1g-dev
-      tags: 
-        - python
-        
+  - name: install packages needed to compile python
+    apt:
+      name={{ item }}
+      state=latest
+    with_items:
+      - autotools-dev
+      - blt-dev
+      - bzip2
+      - dpkg-dev
+      - g++-multilib
+      - gcc-multilib
+      - libbluetooth-dev
+      - libbz2-dev
+      - libexpat1-dev
+      - libffi-dev
+      - libffi6
+      - libffi6-dbg
+      - libgdbm-dev
+      - libgpm2
+      - libncursesw5-dev
+      - libreadline-dev
+      - libsqlite3-dev
+      - libssl-dev
+      - libtinfo-dev
+      - mime-support
+      - net-tools
+      - netbase
+      - python-crypto
+      - python-mox3
+      - python-pil
+      - python-ply
+      - quilt
+      - tk-dev
+      - zlib1g-dev
+      
   - name: Download python source
     get_url:
       url="{{ python_source }}"

--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -26,6 +26,7 @@
       - libffi-dev
       - libffi6
       - libffi6-dbg
+      - libc6-dev
       - libgdbm-dev
       - libgpm2
       - libncursesw5-dev

--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -6,6 +6,48 @@
     - python
 
 - block:
+    - name: update apt-get cache
+      apt: update-cache=yes
+      tags: 
+        - python
+
+    - name: install packages needed to compile python
+      apt:
+        name={{ item }}
+        state=latest
+      with_items:
+        - autotools-dev
+        - blt-dev
+        - bzip2
+        - dpkg-dev
+        - g++-multilib
+        - gcc-multilib
+        - libbluetooth-dev
+        - libbz2-dev
+        - libexpat1-dev
+        - libffi-dev
+        - libffi6
+        - libffi6-dbg
+        - libgdbm-dev
+        - libgpm2
+        - libncursesw5-dev
+        - libreadline-dev
+        - libsqlite3-dev
+        - libssl-dev
+        - libtinfo-dev
+        - mime-support
+        - net-tools
+        - netbase
+        - python-crypto
+        - python-mox3
+        - python-pil
+        - python-ply
+        - quilt
+        - tk-dev
+        - zlib1g-dev
+      tags: 
+        - python
+        
   - name: Download python source
     get_url:
       url="{{ python_source }}"


### PR DESCRIPTION
Apparently, if you don't have a bunch of additional libraries installed, then Python compiles without a bunch of features.

I discovered that we couldn't pip install Twisted, a transitive dependency, because Python couldn't unzip a bz2 file, because the libraries were not available during the build process.

This adds the missing dependencies. I tested the build on the VM, and verified that Python could then install all the dependencies.