### PR TITLE
remove deps-traptor tag from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ env:
   - TAGS='miniconda'
   - TAGS='site-tangelo'
   - TAGS='mysql'
-  - TAGS='deps-traptor'
   - TAGS='site-es-hadoop'
   - TAGS='site-tarsnap'
   - TAGS='site-phantomjs'


### PR DESCRIPTION
Traptor is now under docker and not supervisor, so this tag is not needed for testing.