### PR TITLE
Add system level optimizations for Redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ env:
   - TAGS='site-supervisord'
   - TAGS='site-oozie'
   - TAGS='site-exim'
+  - TAGS='site-redis'
 
 matrix:
   fast_finish: true

--- a/roles/redis/tasks/server.yml
+++ b/roles/redis/tasks/server.yml
@@ -40,3 +40,25 @@
   notify:
     - reread supervisord
   tags: redis
+
+###############################################################################
+# System level configuration optimizations. Configuration recommendations taken
+# from https://redis.io/topics/admin
+###############################################################################
+- block:
+  - name: Enable vm.overcommit_memory=1
+    sysctl:
+      name: vm.overcommit_memory
+      value: 1
+      state: present
+
+  - name: Install sysfsutils package
+    apt:
+      name: sysfsutils
+      state: present
+
+  - name: Disable Transparent HugePage
+    lineinfile:
+      dest: /etc/sysfs.conf
+      line: kernel/mm/transparent_hugepage/enabled = never
+      state: present

--- a/roles/redis/tasks/server.yml
+++ b/roles/redis/tasks/server.yml
@@ -62,3 +62,4 @@
       dest: /etc/sysfs.conf
       line: kernel/mm/transparent_hugepage/enabled = never
       state: present
+  tags: redis


### PR DESCRIPTION
This PR adds system level configuration optimizations for Redis as described in the [Redis Admin documentation](https://redis.io/topics/admin).

## Testing

Alter the `group_vars/all` file to include the following:

	redis_maxmemory: 1024m

Run the redis role against the `vagrant-as-01` VM

	$ ansible-playbook -u vagrant -i staging.inventory --limit=vagrant-as-01 --tags=site-redis site-infrastructure.yml
    
Reboot the VM

	$ vagrant halt vagrant-as-01 && vagrant up vagrant-as-01
    
SSH into the vm

	$ vagrant ssh vagrant-as-01
    
Inside the VM, run the `redis-cli`

	(vagrant-as-01)$ /opt/redis/default/bin/redis-cli
    
From the `redis-cli`, execute the following to get the `maxmemory` configuration value

	(vagrant-as-01)
    127.0.0.1:6379> config get maxmemory
	1) "maxmemory"
	2) "1024000000"
    
Exit the `redis-cli`. Test the transparent hugepage configuration by running the following:

    vagrant@vagrant-as-01:~$ cat /sys/kernel/mm/transparent_hugepage/enabled
    always madvise [never]
    
Verify overcommit memory is enabled:

    vagrant@vagrant-as-01:~$ sysctl vm.overcommit_memory
    vm.overcommit_memory = 1