### PR TITLE
Add PHP Role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ env:
   - TAGS='site-oozie'
   - TAGS='site-exim'
   - TAGS='site-redis'
+  - TAGS='site-php'
 
 matrix:
   fast_finish: true

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+
+php_version: 5.6
+php_extensions:
+  - mcrypt
+  - mbstring
+  - mysql
+  - gd
+  - intl
+  - xsl
+  - zip
+  - fpm
+  - mysqlnd
+  - mcrypt
+  - imap
+  - curl
+  - cli
+  - common
+  - dev
+  - gd
+  - json
+php_apache_enabled: true

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Install add-apt-repository dependencies
+  apt:
+    name: "{{ item }}"
+    update_cache: yes
+  with_items:
+    - software-properties-common
+    - python-software-properties
+
+- name: Add PHP PPAs
+  apt_repository:
+    repo: "{{ item }}"
+  with_items:
+    - ppa:ondrej/php
+    - ppa:ondrej/php5-compat
+
+- name: Install PHP {{ php_version }}
+  apt:
+    name: php{{ php_version }}
+    update_cache: yes
+
+- name: Install PHP extensions
+  apt:
+    name: php{{ php_version }}-{{ item }}
+  with_items: "{{ php_extensions }}"
+
+#########################################################
+# Apache configurations
+#########################################################
+- block:
+  - name: Install libapache php extension
+    apt:
+      name: libapache2-mod-php{{ php_version }}
+
+  - name: Disable existing php apache extension
+    apache2_module:
+      state: absent
+      name: php5
+    ignore_errors: yes
+
+  - name: Enable new php apache extension
+    apache2_module:
+      state: absent
+      name: php{{ php_version }}
+  when: php_apache_enabled
+
+- name: Use update-alternative to set active php to {{ php_version }}
+  alternatives:
+    name: php
+    path: /usr/bin/php{{ php_version }}

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -407,3 +407,11 @@
   roles: [ phantomjs ]
   tags:
     - site-phantomjs
+
+# ------------------------------------ PHP ----------------------------------
+
+- name: Run php role
+  hosts: php-nodes
+  roles: [php]
+  tags:
+    - site-php

--- a/staging.inventory
+++ b/staging.inventory
@@ -164,3 +164,6 @@ vagrant-as-01
 [phantomjs-nodes:children]
 storm-nodes
 spark-nodes
+
+[php-nodes]
+vagrant-as-01

--- a/testing.inventory
+++ b/testing.inventory
@@ -162,3 +162,6 @@ travis-trusty
 [phantomjs-nodes:children]
 storm-nodes
 spark-nodes
+
+[php-nodes]
+travis-trusty


### PR DESCRIPTION
This PR allows for installation of php and php extensions.

## Testing

Run the php role against vagrant-as-01

    $ ansible-playbook -i staging.inventory -u vagrant --limit=vagrant-as-01 --tags="site-php" site-infrastructure.yml
    
SSH into vagrant-as-01

    $ vagrant ssh vagrant-as-01
    
Check the PHP version. It should be 5.6 by default.

    (vagrant-as-01)$ php --version    
    PHP 5.6.30-12~ubuntu14.04.1+deb.sury.org+1 (cli)
    Copyright (c) 1997-2016 The PHP Group
    Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies
        with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies
    
Check the PHP extensions were installed correctly.

    (vagrant-as-01)$ php -m | grep -P '(curl|zip|xsl|imap)'
    curl
    imap
    xsl
    zip
    
Log out of vagrant-as-01.
    
Edit the `php_version` variable in `roles/php/defaults/main.yml` to be `7.0`. Run the php role again.

    $ ansible-playbook -i staging.inventory -u vagrant --limit=vagrant-as-01 --tags="site-php" site-infrastructure.yml

SSH into vagrant-as-01

    $ vagrant ssh vagrant-as-01
    
Check the PHP version. It should be 7.0 now.

    (vagrant-as-01)$ php --version
    PHP 7.0.20-1~ubuntu14.04.1+deb.sury.org+1 (cli) (built: Jun  9 2017 08:27:48) ( NTS )
    Copyright (c) 1997-2017 The PHP Group
    Zend Engine v3.0.0, Copyright (c) 1998-2017 Zend Technologies
        with Zend OPcache v7.0.20-1~ubuntu14.04.1+deb.sury.org+1, Copyright (c) 1999-2017, by Zend Technologies
    
Check the PHP extensions were installed correctly.

    (vagrant-as-01)$ php -m | grep -P '(curl|zip|xsl|imap)'
    curl
    imap
    xsl
    zip