### PR TITLE
Adding flag to compile Python with unicode support.

### DIFF
--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -61,7 +61,7 @@
     args:
       chdir: "/tmp/Python-{{ python_version }}"
     with_items:
-      - "./configure --prefix {{ python_install_dir }}"
+      - "./configure --prefix {{ python_install_dir }} --enable-unicode=ucs4"
       - "make"
       - "make altinstall"
 


### PR DESCRIPTION
This adds the missing UCS4 support. 

**Testing**
If you've already run this role before, then you will need to remove (or rename) the existing Python install located at `/usr/local/lib/python2.7.11` before running again, or this role will not recompile it.

1) Create a simple playbook to run a single role:
```
---
# Play:   run_role.yml
# Usage:  ansible-playbook -i inventory run_role.yml -e "ROLE=<role>" -e "HOST=<hostname|group>"

- hosts:  '{{HOSTS}}'
  roles:
  - { role: '{{ROLE}}' }
```

2) Run the role: 
```
ansible-playbook -i staging.inventory run_role.yml -e "ROLE=python" -e "HOSTS=vagrant-as-01"
```

3) Confirm the build by running the following commands as seen below and look for `cp27mu`. Without the flag introduced in this PR you will only find `cp27m`.
```
$ vitualenv --python=/usr/local/lib/python2.7.11/bin/python2.7 test`
$ source test/bin/activate
$ python 
Python 2.7.6 (default, Oct 26 2016, 20:30:19)
[GCC 4.8.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pip; print(pip.pep425tags.get_supported())
[('cp27', 'cp27mu', 'manylinux1_x86_64'), ('cp27', 'cp27mu', 'linux_x86_64'), ('cp27', 'none', 'manylinux1_x86_64'), ('cp27', 'none', 'linux_x86_64'), ('py2', 'none', 'manylinux1_x86_64'), ('py2', 'none', 'linux_x86_64'), ('cp27', 'none', 'any'), ('cp2', 'none', 'any'), ('py27', 'none', 'any'), ('py2', 'none', 'any'), ('py26', 'none', 'any'), ('py25', 'none', 'any'), ('py24', 'none', 'any'), ('py23', 'none', 'any'), ('py22', 'none', 'any'), ('py21', 'none', 'any'), ('py20', 'none', 'any')]
```
