### PR TITLE
Make redis installation more consistent to support sentinel

### DIFF
--- a/roles/redis/tasks/install.yml
+++ b/roles/redis/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: install dependencies
-  yum: 
+  yum:
     name={{ item }}
     state=present
   with_items:
@@ -33,44 +33,49 @@
     system=yes
   tags: redis
 
-- name: download redis
-  get_url: 
-    url={{ repository_infrastructure }}/redis-{{ redis_version }}.tar.gz
-    dest=/usr/local/src/redis-{{ redis_version }}.tar.gz
-    validate_certs=no
+- name: Download and build redis
+  block:
+    - name: download redis
+      get_url:
+        url={{ repository_infrastructure }}/redis-{{ redis_version }}.tar.gz
+        dest=/usr/local/src/redis-{{ redis_version }}.tar.gz
+        validate_certs=no
+
+    - name: extract redis tarball
+      shell: tar xf /usr/local/src/redis-{{ redis_version }}.tar.gz -C /usr/local/src
+        creates=/usr/local/src/redis-{{ redis_version }}
+
+    - name: build dependencies
+      make:
+        target: '{{ item }}'
+        chdir: /usr/local/src/redis-{{ redis_version }}/deps
+      with_items:
+        - hiredis
+        - lua
+        - jemalloc
+        - linenoise
+
+    - name: build redis
+      make:
+        chdir: /usr/local/src/redis-{{ redis_version }}
+
+    - name: create /var/run/redis
+      file:
+        path=/var/run/redis
+        state=directory
+        owner={{ redis_user }}
+
+    - name: install redis
+      command: make PREFIX={{ redis_install_dir }}/redis-{{ redis_version }} install clean
+        chdir=/usr/local/src/redis-{{ redis_version }}
+        creates={{ redis_install_dir }}/redis-{{ redis_version }}/bin/redis-server
+
+    - name: create redis symlink
+      file:
+        path={{ redis_install_dir }}/default
+        state=link
+        src={{ redis_install_dir }}/redis-{{ redis_version }}
   when: redis.stat.isdir is not defined
   tags: redis
 
-- name: extract redis tarball
-  shell: tar xf /usr/local/src/redis-{{ redis_version }}.tar.gz -C /usr/local/src
-    creates=/usr/local/src/redis-{{ redis_version }}
-  when: redis.stat.isdir is not defined
-  tags: redis
 
-- name: compile redis
-  command: make -j5
-    chdir=/usr/local/src/redis-{{ redis_version }}
-    creates=/usr/local/src/redis-{{ redis_version }}/src/redis-server
-  when: redis.stat.isdir is not defined
-  tags: redis
-
-- name: create /var/run/redis
-  file: 
-    path=/var/run/redis
-    state=directory
-    owner={{ redis_user }}
-  tags: redis
-
-- name: install redis
-  command: make PREFIX={{ redis_install_dir }}/redis-{{ redis_version }} install clean
-    chdir=/usr/local/src/redis-{{ redis_version }}
-    creates={{ redis_install_dir }}/redis-{{ redis_version }}/bin/redis-server
-  when: redis.stat.isdir is not defined
-  tags: redis
-
-- name: create redis symlink
-  file:
-    path={{ redis_install_dir }}/default
-    state=link
-    src={{ redis_install_dir }}/redis-{{ redis_version }}
-  tags: redis

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -121,25 +121,32 @@
     - ELK
 
 # --------------------------- Scraper services -------------------------------
-- block:
-	- name: configure the master redis server
-	  hosts: redis-master
-	  roles: [ redis ]
+- name: configure the master redis server
+  hosts: redis-master
+  roles: [ redis ]
+  tags:
+    - site-redis
+    - scrapy-services
+    - deps-traptor
 
-	- name: configure redis slaves
-	  hosts: redis-slave
-	  vars:
-		- redis_slaveof: "{{ groups['redis-master'][0] }} {{ redis_port }}"
-	  roles: [ redis ]
+- name: configure redis slaves
+  hosts: redis-slave
+  vars:
+    - redis_slaveof: "{{ groups['redis-master'][0] }} {{ redis_port }}"
+  roles: [ redis ]
+  tags:
+    - site-redis
+    - scrapy-services
+    - deps-traptor
 
-	- name: configure redis sentinel nodes
-	  hosts: redis-sentinel
-	  vars:
-		- redis_sentinel_monitors:
-		  - name: master01
-			host: "{{ groups['redis-master'][0] }}"
-			port: "{{ redis_port }}"
-	  roles: [ redis ]
+- name: configure redis sentinel nodes
+  hosts: redis-sentinel
+  vars:
+    - redis_sentinel_monitors:
+      - name: redis-symphony
+        host: "{{ groups['redis-master'][0] }}"
+        port: "{{ redis_port }}"
+  roles: [ redis ]
   tags:
     - site-redis
     - scrapy-services

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -122,7 +122,7 @@
 
 # --------------------------- Scraper services -------------------------------
 - name: configure the master redis server
-  hosts: redis-master
+  hosts: redis-master-node
   roles: [ redis ]
   tags:
     - site-redis
@@ -130,9 +130,9 @@
     - deps-traptor
 
 - name: configure redis slaves
-  hosts: redis-slave
+  hosts: redis-slave-nodes
   vars:
-    - redis_slaveof: "{{ groups['redis-master'][0] }} {{ redis_port }}"
+    - redis_slaveof: "{{ groups['redis-master-node'][0] }} {{ redis_port }}"
   roles: [ redis ]
   tags:
     - site-redis
@@ -140,11 +140,11 @@
     - deps-traptor
 
 - name: configure redis sentinel nodes
-  hosts: redis-sentinel
+  hosts: redis-sentinel-nodes
   vars:
     - redis_sentinel_monitors:
       - name: redis-symphony
-        host: "{{ groups['redis-master'][0] }}"
+        host: "{{ groups['redis-master-node'][0] }}"
         port: "{{ redis_port }}"
   roles: [ redis ]
   tags:

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -121,13 +121,30 @@
     - ELK
 
 # --------------------------- Scraper services -------------------------------
-- name: Run redis role
-  hosts: redis-nodes
-  roles: [ redis ]
+- block:
+	- name: configure the master redis server
+	  hosts: redis-master
+	  roles: [ redis ]
+
+	- name: configure redis slaves
+	  hosts: redis-slave
+	  vars:
+		- redis_slaveof: "{{ groups['redis-master'][0] }} {{ redis_port }}"
+	  roles: [ redis ]
+
+	- name: configure redis sentinel nodes
+	  hosts: redis-sentinel
+	  vars:
+		- redis_sentinel_monitors:
+		  - name: master01
+			host: "{{ groups['redis-master'][0] }}"
+			port: "{{ redis_port }}"
+	  roles: [ redis ]
   tags:
     - site-redis
     - scrapy-services
     - deps-traptor
+
 
 - name: Run tor role
   hosts: tor-proxy

--- a/site-infrastructure.yml
+++ b/site-infrastructure.yml
@@ -146,6 +146,7 @@
       - name: redis-symphony
         host: "{{ groups['redis-master-node'][0] }}"
         port: "{{ redis_port }}"
+    - redis_sentinel: True
   roles: [ redis ]
   tags:
     - site-redis


### PR DESCRIPTION
This PR introduces changes to the compilation process which resulted in more consistent successful builds.

This PR also includes instructions on how to provision and test a Redis sentinel set up.

# Instructions

Temporarily update the staging.inventory file to include the following:

```
[redis-master-node]
vagrant-as-01

[redis-slave-nodes]
vagrant-as-02

[redis-sentinel-nodes]
vagrant-as-sent-01
vagrant-as-sent-02
vagrant-as-sent-03
```

Temporarily append the following to the `vagrant_hosts` file so we can provision sentinel nodes:

```
192.168.33.103   vagrant-as-sent-01  vas-sent01  ubuntu
192.168.33.104   vagrant-as-sent-02  vas-sent02  ubuntu
192.168.33.105   vagrant-as-sent-03  vas-sent03  ubuntu
```

Temporarily append the following to the `/etc/hosts` file on your system:

```
192.168.33.103   vagrant-as-sent-01
192.168.33.104   vagrant-as-sent-02
192.168.33.105   vagrant-as-sent-03
```

Bring up the cluster:

    $ vagrant up

Run `vagrant status` to verify all the machines have been brought up:

```
$ vagrant status
Current machine states:

vagrant-as-01             running (virtualbox)
vagrant-as-02             running (virtualbox)
vagrant-as-sent-01        running (virtualbox)
vagrant-as-sent-02        running (virtualbox)
vagrant-as-sent-03        running (virtualbox)
```

Execute the following ssh command to verify we can connect to the newly provisioned sentinel nodes

```
$ ssh vagrant@vagrant-as-sent-01 pwd
```

Run the ansible playbook:

```
$ ansible-playbook -i staging.inventory -u vagrant --tags=site-redis site-infrastructure.yml
``` 

Download this python script, which connects to redis via the Sentinels: https://gist.github.com/joequery/340e800cf3ac51702c8c131ede827bee

Run the script. Observe that initially the master / slaves are logged as:

```
('redis_master', ('192.168.33.101', 6379))
('redis_slaves', [('192.168.33.102', 6379)])
```

The script reads the value of the `ansible` key in Redis. The value of the key is a timestamp of when the key was last written to by the master. As long as a master is present, the timestamp will update.

The script will print the timestamp if a slave is present. Note that in the event only one node is available, it will function as master and slave until another node becomes available.

If you shutdown the master via `vagrant halt`,  the slave should assume the role of master after 30 seconds. The debug log should reflect this. After the slave has been promoted to master, powering the old master back on will cause it to rejoin as a slave.